### PR TITLE
Implement job lifecycle scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,22 @@ This repository contains the extracted Vite + React installer application in the
    echo "VITE_SUPABASE_API_KEY=YOUR_SUPABASE_ANON_KEY" >> .env
    ```
 4. Start the development server:
+
    ```bash
-5. Open the printed local URL in your browser to see the app. Tailwind CSS styles are loaded automatically.
+
    ```
-4. Start the development server:
+
+5. Open the printed local URL in your browser to see the app. Tailwind CSS styles are loaded automatically.
+
+   ```
+
+   ```
+
+6. Start the development server:
    ```bash
    npm run dev
    ```
-5. Open the printed local URL in your browser to see the app. Tailwind CSS styles are loaded automatically.
+7. Open the printed local URL in your browser to see the app. Tailwind CSS styles are loaded automatically.
 
 The original application structure inside `installer-app/` has not been modified.
 
@@ -37,6 +45,7 @@ migrations on your Postgres database before starting the app:
 
 ```bash
 psql $DATABASE_URL -f installer-app/api/migrations/001_create_audit_log.sql
+psql $DATABASE_URL -f installer-app/api/migrations/002_create_job_schema.sql
 ```
 
 Apply any additional migration files in the folder in order when deploying a new

--- a/installer-app/api/migrations/002_create_job_schema.sql
+++ b/installer-app/api/migrations/002_create_job_schema.sql
@@ -1,0 +1,24 @@
+create table if not exists jobs (
+  id uuid primary key default uuid_generate_v4(),
+  clinic_name text not null,
+  contact_name text not null,
+  contact_phone text not null,
+  assigned_to uuid references auth.users(id),
+  status text not null default 'created' check (status in ('created','assigned','in_progress','submitted','complete')),
+  created_at timestamp default now()
+);
+
+create table if not exists job_materials (
+  id uuid primary key default uuid_generate_v4(),
+  job_id uuid references jobs(id) on delete cascade,
+  material_id uuid references materials(id),
+  quantity int not null,
+  used_quantity int default 0
+);
+
+create table if not exists checklist_items (
+  id uuid primary key default uuid_generate_v4(),
+  job_id uuid references jobs(id) on delete cascade,
+  description text not null,
+  completed boolean default false
+);

--- a/installer-app/src/App.jsx
+++ b/installer-app/src/App.jsx
@@ -9,6 +9,11 @@ import MockJobsPage from "./installer/pages/MockJobsPage";
 import FeedbackPage from "./installer/pages/FeedbackPage";
 import InstallManagerDashboard from "./app/install-manager/page.jsx";
 import NewJobBuilderPage from "./app/install-manager/job/NewJobBuilderPage";
+import AdminNewJob from "./app/admin/jobs/NewJobPage";
+import AdminJobDetail from "./app/admin/jobs/JobDetailPage";
+import InstallerDashboard from "./app/installer/InstallerDashboard";
+import InstallerJobPage from "./app/installer/jobs/JobPage";
+import ManagerReview from "./app/manager/ReviewPage";
 
 const ClientsPage = lazy(() => import("./app/clients/ClientsPage"));
 const QuotesPage = lazy(() => import("./app/quotes/QuotesPage"));
@@ -24,23 +29,31 @@ const App = () => (
   <Router>
     <Suspense fallback={<div>Loading...</div>}>
       <Routes>
-      <Route path="/" element={<InstallerHomePage />} />
-      <Route path="/appointments" element={<AppointmentSummaryPage />} />
-      <Route path="/activity" element={<ActivitySummaryPage />} />
-      <Route path="/ifi" element={<IFIDashboard />} />
-      <Route path="/job/:jobId" element={<JobDetailPage />} />
-      <Route path="/mock-jobs" element={<MockJobsPage />} />
-      <Route path="/install-manager" element={<InstallManagerDashboard />} />
-      <Route path="/install-manager/job/new" element={<NewJobBuilderPage />} />
-      <Route path="/feedback" element={<FeedbackPage />} />
-      <Route path="/clients" element={<ClientsPage />} />
-      <Route path="/quotes" element={<QuotesPage />} />
-      <Route path="/invoices" element={<InvoicesPage />} />
-      <Route path="/payments" element={<PaymentsPage />} />
-      <Route path="/messages" element={<MessagesPanel />} />
-      <Route path="/time-tracking" element={<TimeTrackingPanel />} />
-      <Route path="/reports" element={<ReportsPage />} />
-    </Routes>
+        <Route path="/" element={<InstallerHomePage />} />
+        <Route path="/appointments" element={<AppointmentSummaryPage />} />
+        <Route path="/activity" element={<ActivitySummaryPage />} />
+        <Route path="/ifi" element={<IFIDashboard />} />
+        <Route path="/job/:jobId" element={<JobDetailPage />} />
+        <Route path="/mock-jobs" element={<MockJobsPage />} />
+        <Route path="/admin/jobs/new" element={<AdminNewJob />} />
+        <Route path="/admin/jobs/:id" element={<AdminJobDetail />} />
+        <Route path="/installer/dashboard" element={<InstallerDashboard />} />
+        <Route path="/installer/jobs/:id" element={<InstallerJobPage />} />
+        <Route path="/manager/review" element={<ManagerReview />} />
+        <Route path="/install-manager" element={<InstallManagerDashboard />} />
+        <Route
+          path="/install-manager/job/new"
+          element={<NewJobBuilderPage />}
+        />
+        <Route path="/feedback" element={<FeedbackPage />} />
+        <Route path="/clients" element={<ClientsPage />} />
+        <Route path="/quotes" element={<QuotesPage />} />
+        <Route path="/invoices" element={<InvoicesPage />} />
+        <Route path="/payments" element={<PaymentsPage />} />
+        <Route path="/messages" element={<MessagesPanel />} />
+        <Route path="/time-tracking" element={<TimeTrackingPanel />} />
+        <Route path="/reports" element={<ReportsPage />} />
+      </Routes>
     </Suspense>
   </Router>
 );

--- a/installer-app/src/app/admin/jobs/JobDetailPage.tsx
+++ b/installer-app/src/app/admin/jobs/JobDetailPage.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from "react";
+import { useParams } from "react-router-dom";
+import { SZInput } from "../../../components/ui/SZInput";
+import { SZButton } from "../../../components/ui/SZButton";
+import { SZTable } from "../../../components/ui/SZTable";
+import { useJobs } from "../../../lib/hooks/useJobs";
+import { useJobMaterials } from "../../../lib/hooks/useJobMaterials";
+
+const JobDetailPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const { jobs, assignJob } = useJobs();
+  const { items, updateUsed } = useJobMaterials(id || "");
+  const job = jobs.find((j) => j.id === id);
+  const [installerId, setInstallerId] = useState(job?.assigned_to || "");
+
+  const handleAssign = async () => {
+    if (id && installerId) {
+      await assignJob(id, installerId);
+    }
+  };
+
+  if (!job) return <p className="p-4">Job not found</p>;
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">{job.clinic_name}</h1>
+      <SZInput
+        id="installer"
+        label="Assign Installer"
+        value={installerId}
+        onChange={setInstallerId}
+      />
+      <SZButton onClick={handleAssign}>Assign</SZButton>
+      <h2 className="text-xl font-semibold mt-4">Materials</h2>
+      <SZTable headers={["Material", "Qty", "Used"]}>
+        {items.map((m) => (
+          <tr key={m.id} className="border-t">
+            <td className="p-2 border">{m.material_id}</td>
+            <td className="p-2 border text-right">{m.quantity}</td>
+            <td className="p-2 border">
+              <input
+                type="number"
+                value={m.used_quantity}
+                className="border rounded px-2 py-1 w-16"
+                onChange={(e) => updateUsed(m.id, Number(e.target.value))}
+              />
+            </td>
+          </tr>
+        ))}
+      </SZTable>
+    </div>
+  );
+};
+
+export default JobDetailPage;

--- a/installer-app/src/app/admin/jobs/NewJobPage.tsx
+++ b/installer-app/src/app/admin/jobs/NewJobPage.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+import { SZInput } from "../../../components/ui/SZInput";
+import { SZButton } from "../../../components/ui/SZButton";
+import { useJobs } from "../../../lib/hooks/useJobs";
+
+const NewJobPage: React.FC = () => {
+  const { createJob } = useJobs();
+  const [clinic, setClinic] = useState("");
+  const [contact, setContact] = useState("");
+  const [phone, setPhone] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleCreate = async () => {
+    setLoading(true);
+    try {
+      await createJob({
+        clinic_name: clinic,
+        contact_name: contact,
+        contact_phone: phone,
+      });
+      setClinic("");
+      setContact("");
+      setPhone("");
+      alert("Job created");
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">New Job</h1>
+      <SZInput
+        id="clinic"
+        label="Clinic Name"
+        value={clinic}
+        onChange={setClinic}
+      />
+      <SZInput
+        id="contact"
+        label="Contact Name"
+        value={contact}
+        onChange={setContact}
+      />
+      <SZInput
+        id="phone"
+        label="Contact Phone"
+        value={phone}
+        onChange={setPhone}
+      />
+      <SZButton onClick={handleCreate} isLoading={loading}>
+        Create
+      </SZButton>
+    </div>
+  );
+};
+
+export default NewJobPage;

--- a/installer-app/src/app/installer/InstallerDashboard.tsx
+++ b/installer-app/src/app/installer/InstallerDashboard.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { useJobs } from "../../lib/hooks/useJobs";
+
+const InstallerDashboard: React.FC = () => {
+  const { jobs, loading } = useJobs();
+  const myJobs = jobs.filter(
+    (j) => j.status === "assigned" || j.status === "in_progress",
+  );
+
+  if (loading) return <p className="p-4">Loading...</p>;
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Assigned Jobs</h1>
+      <ul className="space-y-2">
+        {myJobs.map((j) => (
+          <li key={j.id} className="p-2 border rounded">
+            <Link
+              to={`/installer/jobs/${j.id}`}
+              className="text-blue-600 underline"
+            >
+              {j.clinic_name}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default InstallerDashboard;

--- a/installer-app/src/app/installer/jobs/JobPage.tsx
+++ b/installer-app/src/app/installer/jobs/JobPage.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+import { SZButton } from "../../../components/ui/SZButton";
+import SZChecklist from "../../../components/ui/SZChecklist";
+import { useJobs } from "../../../lib/hooks/useJobs";
+import { useChecklist } from "../../../lib/hooks/useChecklist";
+import { useJobMaterials } from "../../../lib/hooks/useJobMaterials";
+
+const JobPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const { jobs, updateStatus } = useJobs();
+  const { items, toggleItem } = useChecklist(id || "");
+  const { items: mats } = useJobMaterials(id || "");
+  const job = jobs.find((j) => j.id === id);
+
+  if (!job) return <p className="p-4">Job not found</p>;
+
+  const checklistItems = items.map((c) => ({ ...c, onToggle: toggleItem }));
+
+  const handleSubmit = async () => {
+    if (id) await updateStatus(id, "submitted");
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">{job.clinic_name}</h1>
+      <h2 className="text-xl font-semibold">Checklist</h2>
+      <SZChecklist items={checklistItems} />
+      <h2 className="text-xl font-semibold">Materials</h2>
+      <ul className="list-disc pl-5 space-y-1">
+        {mats.map((m) => (
+          <li key={m.id}>
+            {m.material_id}: {m.used_quantity}/{m.quantity}
+          </li>
+        ))}
+      </ul>
+      <SZButton onClick={handleSubmit}>Submit Job</SZButton>
+    </div>
+  );
+};
+
+export default JobPage;

--- a/installer-app/src/app/manager/ReviewPage.tsx
+++ b/installer-app/src/app/manager/ReviewPage.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { SZButton } from "../../components/ui/SZButton";
+import { useJobs } from "../../lib/hooks/useJobs";
+
+const ReviewPage: React.FC = () => {
+  const { jobs, updateStatus } = useJobs();
+  const submitted = jobs.filter((j) => j.status === "submitted");
+
+  const handleComplete = async (id: string) => {
+    await updateStatus(id, "complete");
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Submitted Jobs</h1>
+      <ul className="space-y-2">
+        {submitted.map((j) => (
+          <li key={j.id} className="p-2 border rounded flex justify-between">
+            <span>{j.clinic_name}</span>
+            <SZButton size="sm" onClick={() => handleComplete(j.id)}>
+              Mark Complete
+            </SZButton>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ReviewPage;

--- a/installer-app/src/components/ui/SZChecklist.tsx
+++ b/installer-app/src/components/ui/SZChecklist.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+export interface ChecklistItem {
+  id: string;
+  description: string;
+  completed: boolean;
+  onToggle?: (id: string, completed: boolean) => void;
+}
+
+export interface SZChecklistProps {
+  items: ChecklistItem[];
+  className?: string;
+}
+
+export const SZChecklist: React.FC<SZChecklistProps> = ({
+  items,
+  className = "",
+}) => {
+  return (
+    <ul className={`space-y-2 ${className}`.trim()}>
+      {items.map((item) => (
+        <li key={item.id} className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={item.completed}
+            onChange={() => item.onToggle?.(item.id, !item.completed)}
+            className="form-checkbox text-green-600 h-5 w-5"
+          />
+          <span className={item.completed ? "line-through text-green-600" : ""}>
+            {item.description}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default SZChecklist;

--- a/installer-app/src/lib/hooks/useChecklist.ts
+++ b/installer-app/src/lib/hooks/useChecklist.ts
@@ -1,0 +1,53 @@
+import { useState, useEffect, useCallback } from "react";
+import supabase from "../supabaseClient";
+
+export interface ChecklistItem {
+  id: string;
+  job_id: string;
+  description: string;
+  completed: boolean;
+}
+
+export function useChecklist(jobId: string) {
+  const [items, setItems] = useState<ChecklistItem[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchItems = useCallback(async () => {
+    if (!jobId) return;
+    setLoading(true);
+    const { data, error } = await supabase
+      .from<ChecklistItem>("checklist_items")
+      .select("id, job_id, description, completed")
+      .eq("job_id", jobId)
+      .order("id");
+    if (error) {
+      setError(error.message);
+      setItems([]);
+    } else {
+      setItems(data ?? []);
+      setError(null);
+    }
+    setLoading(false);
+  }, [jobId]);
+
+  const toggleItem = useCallback(async (id: string, completed: boolean) => {
+    const { data, error } = await supabase
+      .from<ChecklistItem>("checklist_items")
+      .update({ completed })
+      .eq("id", id)
+      .select()
+      .single();
+    if (error) throw error;
+    setItems((items) => items.map((i) => (i.id === id ? data : i)));
+    return data;
+  }, []);
+
+  useEffect(() => {
+    fetchItems();
+  }, [fetchItems]);
+
+  return { items, loading, error, fetchItems, toggleItem } as const;
+}
+
+export default useChecklist;

--- a/installer-app/src/lib/hooks/useJobMaterials.ts
+++ b/installer-app/src/lib/hooks/useJobMaterials.ts
@@ -1,0 +1,53 @@
+import { useState, useEffect, useCallback } from "react";
+import supabase from "../supabaseClient";
+
+export interface JobMaterial {
+  id: string;
+  job_id: string;
+  material_id: string;
+  quantity: number;
+  used_quantity: number;
+}
+
+export function useJobMaterials(jobId: string) {
+  const [items, setItems] = useState<JobMaterial[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchItems = useCallback(async () => {
+    if (!jobId) return;
+    setLoading(true);
+    const { data, error } = await supabase
+      .from<JobMaterial>("job_materials")
+      .select("id, job_id, material_id, quantity, used_quantity")
+      .eq("job_id", jobId);
+    if (error) {
+      setError(error.message);
+      setItems([]);
+    } else {
+      setItems(data ?? []);
+      setError(null);
+    }
+    setLoading(false);
+  }, [jobId]);
+
+  const updateUsed = useCallback(async (id: string, used_quantity: number) => {
+    const { data, error } = await supabase
+      .from<JobMaterial>("job_materials")
+      .update({ used_quantity })
+      .eq("id", id)
+      .select()
+      .single();
+    if (error) throw error;
+    setItems((is) => is.map((i) => (i.id === id ? data : i)));
+    return data;
+  }, []);
+
+  useEffect(() => {
+    fetchItems();
+  }, [fetchItems]);
+
+  return { items, loading, error, fetchItems, updateUsed } as const;
+}
+
+export default useJobMaterials;

--- a/installer-app/src/lib/hooks/useJobs.ts
+++ b/installer-app/src/lib/hooks/useJobs.ts
@@ -1,0 +1,90 @@
+import { useState, useEffect, useCallback } from "react";
+import supabase from "../supabaseClient";
+
+export interface Job {
+  id: string;
+  clinic_name: string;
+  contact_name: string;
+  contact_phone: string;
+  assigned_to: string | null;
+  status: string;
+  created_at: string;
+}
+
+export function useJobs() {
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchJobs = useCallback(async () => {
+    setLoading(true);
+    const { data, error } = await supabase
+      .from<Job>("jobs")
+      .select(
+        "id, clinic_name, contact_name, contact_phone, assigned_to, status, created_at",
+      )
+      .order("created_at", { ascending: false });
+    if (error) {
+      setError(error.message);
+      setJobs([]);
+    } else {
+      setJobs(data ?? []);
+      setError(null);
+    }
+    setLoading(false);
+  }, []);
+
+  const createJob = useCallback(
+    async (job: Omit<Job, "id" | "status" | "assigned_to" | "created_at">) => {
+      const { data, error } = await supabase
+        .from<Job>("jobs")
+        .insert({ ...job })
+        .select()
+        .single();
+      if (error) throw error;
+      setJobs((j) => [data, ...j]);
+      return data;
+    },
+    [],
+  );
+
+  const assignJob = useCallback(async (id: string, userId: string) => {
+    const { data, error } = await supabase
+      .from<Job>("jobs")
+      .update({ assigned_to: userId, status: "assigned" })
+      .eq("id", id)
+      .select()
+      .single();
+    if (error) throw error;
+    setJobs((js) => js.map((j) => (j.id === id ? data : j)));
+    return data;
+  }, []);
+
+  const updateStatus = useCallback(async (id: string, status: string) => {
+    const { data, error } = await supabase
+      .from<Job>("jobs")
+      .update({ status })
+      .eq("id", id)
+      .select()
+      .single();
+    if (error) throw error;
+    setJobs((js) => js.map((j) => (j.id === id ? data : j)));
+    return data;
+  }, []);
+
+  useEffect(() => {
+    fetchJobs();
+  }, [fetchJobs]);
+
+  return {
+    jobs,
+    loading,
+    error,
+    fetchJobs,
+    createJob,
+    assignJob,
+    updateStatus,
+  } as const;
+}
+
+export default useJobs;


### PR DESCRIPTION
## Summary
- add migration for jobs, job materials and checklists
- expose hooks for jobs, job materials and checklist items
- build basic admin, installer and manager pages
- wire new routes into the app
- include SZChecklist component

## Testing
- `npm run format` *(success)*
- `npm test` *(failed: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68572236e1f0832db0fe416927513946