### PR TITLE
Filter installer dashboard jobs by assigned user

### DIFF
--- a/installer-app/src/app/installer/InstallerDashboard.tsx
+++ b/installer-app/src/app/installer/InstallerDashboard.tsx
@@ -1,11 +1,16 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { useJobs } from "../../lib/hooks/useJobs";
+import { useAuth } from "../../lib/hooks/useAuth";
 
 const InstallerDashboard: React.FC = () => {
+  const { session } = useAuth();
+  const currentUserId = session?.user?.id;
   const { jobs, loading } = useJobs();
   const myJobs = jobs.filter(
-    (j) => j.status === "assigned" || j.status === "in_progress",
+    (j) =>
+      (j.status === "assigned" || j.status === "in_progress") &&
+      j.assigned_to === currentUserId,
   );
 
   if (loading) return <p className="p-4">Loading...</p>;

--- a/installer-app/src/lib/hooks/useAuth.ts
+++ b/installer-app/src/lib/hooks/useAuth.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import supabase from "../supabaseClient";
+
+export interface AuthSession {
+  user: {
+    id: string;
+  } | null;
+  [key: string]: any;
+}
+
+export function useAuth() {
+  const [session, setSession] = useState<AuthSession | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(data.session as AuthSession | null);
+    });
+
+    const { data: listener } = supabase.auth.onAuthStateChange(
+      (_event, sess) => {
+        setSession(sess as AuthSession | null);
+      },
+    );
+
+    return () => {
+      listener?.subscription.unsubscribe();
+    };
+  }, []);
+
+  return { session } as const;
+}
+
+export default useAuth;

--- a/installer-app/src/lib/hooks/useJobs.ts
+++ b/installer-app/src/lib/hooks/useJobs.ts
@@ -34,6 +34,25 @@ export function useJobs() {
     setLoading(false);
   }, []);
 
+  const fetchMyJobs = useCallback(async (userId: string) => {
+    setLoading(true);
+    const { data, error } = await supabase
+      .from<Job>("jobs")
+      .select(
+        "id, clinic_name, contact_name, contact_phone, assigned_to, status, created_at",
+      )
+      .eq("assigned_to", userId)
+      .order("created_at", { ascending: false });
+    if (error) {
+      setError(error.message);
+      setJobs([]);
+    } else {
+      setJobs(data ?? []);
+      setError(null);
+    }
+    setLoading(false);
+  }, []);
+
   const createJob = useCallback(
     async (job: Omit<Job, "id" | "status" | "assigned_to" | "created_at">) => {
       const { data, error } = await supabase
@@ -80,6 +99,7 @@ export function useJobs() {
     jobs,
     loading,
     error,
+    fetchMyJobs,
     fetchJobs,
     createJob,
     assignJob,


### PR DESCRIPTION
## Summary
- add `useAuth` hook for supabase session management
- extend `useJobs` with `fetchMyJobs`
- filter installer dashboard jobs using current user id

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68573bab6df8832d8b7caa1eb0edad2a