### PR TITLE
Implement Supabase auth hook with role support

### DIFF
--- a/installer-app/src/components/RequireAuth.tsx
+++ b/installer-app/src/components/RequireAuth.tsx
@@ -1,0 +1,16 @@
+import React, { ReactElement } from "react";
+import { Navigate } from "react-router-dom";
+import useAuth from "../lib/hooks/useAuth";
+
+interface Props {
+  children: ReactElement;
+  redirectTo?: string;
+}
+
+export default function RequireAuth({ children, redirectTo = "/login" }: Props) {
+  const { session, loading } = useAuth();
+
+  if (loading) return null;
+  if (!session) return <Navigate to={redirectTo} replace />;
+  return children;
+}

--- a/installer-app/src/components/RequireRole.tsx
+++ b/installer-app/src/components/RequireRole.tsx
@@ -1,0 +1,22 @@
+import React, { ReactElement } from "react";
+import { Navigate } from "react-router-dom";
+import useAuth from "../lib/hooks/useAuth";
+
+interface Props {
+  role: string | string[];
+  children: ReactElement;
+  redirectTo?: string;
+}
+
+export default function RequireRole({ role: required, children, redirectTo = "/" }: Props) {
+  const { role, loading } = useAuth();
+
+  if (loading) return null;
+
+  const roles = Array.isArray(required) ? required : [required];
+  if (!roles.includes(role ?? "")) {
+    return <Navigate to={redirectTo} replace />;
+  }
+
+  return children;
+}

--- a/installer-app/src/lib/hooks/useAuth.tsx
+++ b/installer-app/src/lib/hooks/useAuth.tsx
@@ -1,0 +1,62 @@
+import { useState, useEffect } from "react";
+import supabase from "../supabaseClient";
+
+interface RoleRow {
+  id: string;
+  role: string;
+}
+
+export default function useAuth() {
+  const [session, setSession] = useState<null | any>(null);
+  const [role, setRole] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchRole = async (userId?: string | null) => {
+    if (!userId) {
+      setRole(null);
+      return;
+    }
+    const { data, error } = await supabase
+      .from<RoleRow>("user_roles")
+      .select("role")
+      .eq("id", userId)
+      .single();
+    if (error) {
+      console.error(error);
+      setRole(null);
+    } else {
+      setRole(data?.role ?? null);
+    }
+  };
+
+  useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout>;
+
+    const getSession = async () => {
+      const { data } = await supabase.auth.getSession();
+      setSession(data.session);
+      await fetchRole(data.session?.user?.id);
+      setLoading(false);
+    };
+
+    getSession();
+
+    const { data: listener } = supabase.auth.onAuthStateChange(
+      async (_event, newSession) => {
+        setSession(newSession);
+        await fetchRole(newSession?.user?.id);
+        setLoading(false);
+      },
+    );
+
+    // final fallback in case callbacks don't fire
+    timeout = setTimeout(() => setLoading(false), 10000);
+
+    return () => {
+      listener?.subscription?.unsubscribe();
+      clearTimeout(timeout);
+    };
+  }, []);
+
+  return { session, role, loading } as const;
+}


### PR DESCRIPTION
## Summary
- add a `useAuth` hook that fetches session and role
- include `RequireAuth` and `RequireRole` guards using the new hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68573baa8dec832d988adef574997b42