### PR TITLE
Add feedback API and review panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,24 +18,12 @@ This repository contains the extracted Vite + React installer application in the
    echo "VITE_SUPABASE_API_KEY=YOUR_SUPABASE_ANON_KEY" >> .env
    ```
 4. Start the development server:
-
-   ```bash
-
-   ```
-
-5. Open the printed local URL in your browser to see the app. Tailwind CSS styles are loaded automatically.
-
-   ```
-
-   ```
-
-6. Start the development server:
    ```bash
    npm run dev
    ```
-7. Open the printed local URL in your browser to see the app. Tailwind CSS styles are loaded automatically.
+5. Open the printed local URL in your browser to see the app. Tailwind CSS styles are loaded automatically.
 
-8. Run the test suite:
+6. Run the test suite:
    ```bash
    npm test
    ```

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ migrations on your Postgres database before starting the app:
 ```bash
 psql $DATABASE_URL -f installer-app/api/migrations/001_create_audit_log.sql
 psql $DATABASE_URL -f installer-app/api/migrations/002_create_job_schema.sql
+psql $DATABASE_URL -f installer-app/api/migrations/003_create_user_roles.sql
+psql $DATABASE_URL -f installer-app/api/migrations/004_create_feedback.sql
 ```
 
 Apply any additional migration files in the folder in order when deploying a new

--- a/installer-app/api/feedback.js
+++ b/installer-app/api/feedback.js
@@ -1,0 +1,25 @@
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl =
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+const supabaseAnonKey =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  process.env.VITE_SUPABASE_API_KEY;
+
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const body = req.body || {};
+    const { error } = await supabase.from("feedback").insert({ ...body });
+    if (error) throw error;
+    return res.status(200).json({ ok: true });
+  } catch (err) {
+    console.error("Failed to submit feedback", err);
+    return res.status(500).json({ error: "Failed to submit feedback" });
+  }
+}

--- a/installer-app/api/migrations/004_create_feedback.sql
+++ b/installer-app/api/migrations/004_create_feedback.sql
@@ -1,0 +1,10 @@
+create table if not exists feedback (
+  id uuid primary key default uuid_generate_v4(),
+  installer_name text,
+  job_number text,
+  date date,
+  score int,
+  issues text[],
+  notes text,
+  created_at timestamptz not null default now()
+);

--- a/installer-app/src/__tests__/useInstallerData.test.js
+++ b/installer-app/src/__tests__/useInstallerData.test.js
@@ -33,11 +33,17 @@ test('useIFIScores returns mock data', () => {
   expect(result.current.data).toBeTruthy();
 });
 
-test('submitInstallerFeedback stores feedback', () => {
-  localStorage.clear();
-  submitInstallerFeedback({ hello: 'world' });
-  const stored = JSON.parse(localStorage.getItem('installerFeedbacks'));
-  expect(stored.length).toBe(1);
+test('submitInstallerFeedback posts feedback', async () => {
+  global.fetch.mockClear();
+  await submitInstallerFeedback({ hello: 'world' });
+  expect(global.fetch).toHaveBeenCalledWith(
+    '/api/feedback',
+    expect.objectContaining({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ hello: 'world' }),
+    })
+  );
 });
 
 test('setAppointmentStatus updates storage', () => {

--- a/installer-app/src/app/install-manager/FeedbackReviewPanel.tsx
+++ b/installer-app/src/app/install-manager/FeedbackReviewPanel.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState, useCallback } from "react";
+import supabase from "../../lib/supabaseClient";
+
+interface FeedbackRow {
+  id: string;
+  installer_name?: string | null;
+  job_number?: string | null;
+  date?: string | null;
+  score?: number | null;
+  issues?: string[] | null;
+  notes?: string | null;
+  created_at?: string;
+}
+
+const FeedbackReviewPanel: React.FC = () => {
+  const [feedback, setFeedback] = useState<FeedbackRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchFeedback = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const { data, error } = await supabase
+      .from<FeedbackRow>("feedback")
+      .select("id, installer_name, job_number, date, score, issues, notes, created_at")
+      .order("created_at", { ascending: false });
+    if (error) {
+      setError(error.message);
+    }
+    setFeedback(data ?? []);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    fetchFeedback();
+  }, [fetchFeedback]);
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div className="text-red-600">{error}</div>;
+
+  return (
+    <div className="space-y-4">
+      {feedback.map((f) => (
+        <div key={f.id} className="p-2 rounded bg-gray-50">
+          <div className="font-medium">
+            {f.job_number} - {f.installer_name}
+          </div>
+          <div className="text-sm text-gray-600">Score: {f.score}</div>
+          {f.issues && f.issues.length > 0 && (
+            <div className="text-sm">Issues: {f.issues.join(", ")}</div>
+          )}
+          {f.notes && <div className="text-sm">Notes: {f.notes}</div>}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default FeedbackReviewPanel;

--- a/installer-app/src/app/install-manager/page.jsx
+++ b/installer-app/src/app/install-manager/page.jsx
@@ -6,6 +6,7 @@ import { useJobs } from "./useJobs";
 import EditJobModal from "./EditJobModal";
 import ConfirmDeleteModal from "./ConfirmDeleteModal";
 import QAReviewPanel from "./QAReviewPanel";
+import FeedbackReviewPanel from "./FeedbackReviewPanel";
 import { useNavigate } from "react-router-dom";
 
 export default function InstallManagerDashboard() {
@@ -100,6 +101,8 @@ export default function InstallManagerDashboard() {
       />
       <h2 className="text-xl font-bold mt-8 mb-4">QA Review</h2>
       <QAReviewPanel />
+      <h2 className="text-xl font-bold mt-8 mb-4">Installer Feedback</h2>
+      <FeedbackReviewPanel />
     </div>
   );
 }

--- a/installer-app/src/components/RequireAuth.tsx
+++ b/installer-app/src/components/RequireAuth.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from "react";
 import { Navigate } from "react-router-dom";
-import useAuth from "../lib/hooks/useAuth";
+import { useAuth } from "../lib/hooks/useAuth";
 
 interface Props {
   children: ReactElement;

--- a/installer-app/src/components/RequireRole.tsx
+++ b/installer-app/src/components/RequireRole.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from "react";
 import { Navigate } from "react-router-dom";
-import useAuth from "../lib/hooks/useAuth";
+import { useAuth } from "../lib/hooks/useAuth";
 
 interface Props {
   role: string | string[];

--- a/installer-app/src/installer/hooks/useInstallerData.js
+++ b/installer-app/src/installer/hooks/useInstallerData.js
@@ -139,16 +139,19 @@ export function useActivityLogs() {
   return { logs, loading };
 }
 
-// submitInstallerFeedback would normally post to backend
-export function submitInstallerFeedback(formData) {
+// submitInstallerFeedback now posts to API endpoint
+export async function submitInstallerFeedback(formData) {
   try {
-    const stored = JSON.parse(
-      localStorage.getItem('installerFeedbacks') || '[]'
-    );
-    stored.push({ ...formData, submittedAt: new Date().toISOString() });
-    localStorage.setItem('installerFeedbacks', JSON.stringify(stored));
+    await fetch('/api/feedback', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(formData),
+    });
   } catch (err) {
-    // localStorage may be unavailable or full
+    // network or other errors can be safely ignored in this demo
+    console.error('Failed to submit installer feedback', err);
   }
 }
 


### PR DESCRIPTION
## Summary
- add `api/feedback.js` endpoint to store installer feedback
- send feedback via POST in `submitInstallerFeedback`
- show submitted feedback in new `FeedbackReviewPanel`
- surface panel on Install Manager dashboard
- add migration for new `feedback` table
- update tests for new API behavior
- document migrations in README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685743ca7328832db7960122108a5c9a