### PR TITLE
Disable document buttons awaiting backend features

### DIFF
--- a/installer-app/src/app/install-manager/job/NewJobBuilderPage.tsx
+++ b/installer-app/src/app/install-manager/job/NewJobBuilderPage.tsx
@@ -244,10 +244,18 @@ const NewJobBuilderPage: React.FC = () => {
       </section>
 
       <div className="flex flex-wrap gap-2">
-        <SZButton variant="secondary" size="sm">Generate Installer Documents</SZButton>
-        <SZButton variant="secondary" size="sm">Generate Invoice</SZButton>
-        <SZButton variant="secondary" size="sm">Generate Royalty Contract</SZButton>
-        <SZButton variant="secondary" size="sm">Generate Contracts</SZButton>
+        <SZButton variant="secondary" size="sm" disabled title="Coming soon">
+          Generate Installer Documents
+        </SZButton>
+        <SZButton variant="secondary" size="sm" disabled title="Coming soon">
+          Generate Invoice
+        </SZButton>
+        <SZButton variant="secondary" size="sm" disabled title="Coming soon">
+          Generate Royalty Contract
+        </SZButton>
+        <SZButton variant="secondary" size="sm" disabled title="Coming soon">
+          Generate Contracts
+        </SZButton>
       </div>
 
       <div className="pt-4">


### PR DESCRIPTION
## Summary
- disable document generation buttons in new job builder

## Testing
- `npm test --silent` *(fails: Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6857444ee6c0832da107612749cde707