### PR TITLE
Add upload and inventory modals

### DIFF
--- a/installer-app/src/app/install-manager/AssignInventoryModal.tsx
+++ b/installer-app/src/app/install-manager/AssignInventoryModal.tsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useState } from "react";
+import { SZModal } from "../../components/ui/SZModal";
+import { SZButton } from "../../components/ui/SZButton";
+import supabase from "../../lib/supabaseClient";
+import { useJobMaterials } from "../../lib/hooks/useJobMaterials";
+
+export type AssignInventoryModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  jobId: string | null;
+};
+
+const AssignInventoryModal: React.FC<AssignInventoryModalProps> = ({
+  isOpen,
+  onClose,
+  jobId,
+}) => {
+  const { addMaterial, fetchItems } = useJobMaterials(jobId || "");
+  const [materials, setMaterials] = useState<{ id: string; name: string }[]>([]);
+  const [materialId, setMaterialId] = useState("");
+  const [qty, setQty] = useState(1);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    async function loadMaterials() {
+      const { data } = await supabase
+        .from<{ id: string; name: string }>("materials")
+        .select("id, name");
+      setMaterials(data ?? []);
+    }
+    loadMaterials();
+  }, [isOpen]);
+
+  const handleAdd = async () => {
+    if (!jobId || !materialId) return;
+    setSubmitting(true);
+    try {
+      await addMaterial(materialId, qty);
+      await fetchItems();
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <SZModal isOpen={isOpen} onClose={onClose} title="Assign Inventory">
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700" htmlFor="material">
+            Material
+          </label>
+          <select
+            id="material"
+            className="border rounded px-3 py-2 w-full"
+            value={materialId}
+            onChange={(e) => setMaterialId(e.target.value)}
+          >
+            <option value="">Select</option>
+            {materials.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700" htmlFor="qty">
+            Quantity
+          </label>
+          <input
+            id="qty"
+            type="number"
+            min={1}
+            className="border rounded px-3 py-2 w-full"
+            value={qty}
+            onChange={(e) => setQty(Number(e.target.value))}
+          />
+        </div>
+      </div>
+      <div className="mt-4 flex justify-end gap-2">
+        <SZButton variant="secondary" onClick={onClose} disabled={submitting}>
+          Cancel
+        </SZButton>
+        <SZButton onClick={handleAdd} isLoading={submitting}>
+          Add
+        </SZButton>
+      </div>
+    </SZModal>
+  );
+};
+
+export default AssignInventoryModal;

--- a/installer-app/src/app/install-manager/UploadDocsModal.tsx
+++ b/installer-app/src/app/install-manager/UploadDocsModal.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from "react";
+import { SZModal } from "../../components/ui/SZModal";
+import { SZButton } from "../../components/ui/SZButton";
+import uploadDocument from "../../lib/uploadDocument";
+import supabase from "../../lib/supabaseClient";
+
+export type UploadDocsModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  jobId: string | null;
+  onUploaded?: () => void;
+};
+
+const UploadDocsModal: React.FC<UploadDocsModalProps> = ({
+  isOpen,
+  onClose,
+  jobId,
+  onUploaded,
+}) => {
+  const [files, setFiles] = useState<FileList | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    if (!jobId || !files?.length) return;
+    setSubmitting(true);
+    try {
+      const uploaded: any[] = [];
+      for (const file of Array.from(files)) {
+        const doc = await uploadDocument(file);
+        if (doc) uploaded.push(doc);
+      }
+      if (uploaded.length) {
+        const { data } = await supabase
+          .from("jobs")
+          .select("documents")
+          .eq("id", jobId)
+          .single();
+        const existing = data?.documents ?? [];
+        await supabase
+          .from("jobs")
+          .update({ documents: [...existing, ...uploaded] })
+          .eq("id", jobId);
+      }
+      onUploaded?.();
+      onClose();
+    } catch (err: any) {
+      setError(err.message || "Upload failed");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <SZModal isOpen={isOpen} onClose={onClose} title="Upload Documents">
+      <input
+        type="file"
+        multiple
+        onChange={(e) => setFiles(e.target.files)}
+        className="mb-4"
+      />
+      {error && <div className="text-red-600 text-sm mb-2">{error}</div>}
+      <div className="flex justify-end gap-2">
+        <SZButton variant="secondary" onClick={onClose} disabled={submitting}>
+          Cancel
+        </SZButton>
+        <SZButton onClick={handleSubmit} isLoading={submitting}>
+          Upload
+        </SZButton>
+      </div>
+    </SZModal>
+  );
+};
+
+export default UploadDocsModal;

--- a/installer-app/src/app/install-manager/page.jsx
+++ b/installer-app/src/app/install-manager/page.jsx
@@ -7,17 +7,21 @@ import EditJobModal from "./EditJobModal";
 import ConfirmDeleteModal from "./ConfirmDeleteModal";
 import QAReviewPanel from "./QAReviewPanel";
 import { useNavigate } from "react-router-dom";
+import UploadDocsModal from "./UploadDocsModal";
+import AssignInventoryModal from "./AssignInventoryModal";
 
 export default function InstallManagerDashboard() {
   const { jobs, loading, error, refresh } = useJobs();
   const navigate = useNavigate();
   const [editJob, setEditJob] = useState(null);
   const [deleteJob, setDeleteJob] = useState(null);
+  const [uploadJobId, setUploadJobId] = useState(null);
+  const [inventoryJobId, setInventoryJobId] = useState(null);
 
   const handleView = (id) => navigate(`/install-manager/job/${id}`);
   const handleEdit = (job) => setEditJob(job);
-  const handleUpload = () => alert('Upload documents feature coming soon');
-  const handleAssignInventory = () => alert('Assign inventory feature coming soon');
+  const handleUpload = (id) => setUploadJobId(id);
+  const handleAssignInventory = (id) => setInventoryJobId(id);
 
   return (
     <div className="p-4">
@@ -97,6 +101,17 @@ export default function InstallManagerDashboard() {
             refresh();
           }
         }}
+      />
+      <UploadDocsModal
+        jobId={uploadJobId}
+        isOpen={!!uploadJobId}
+        onClose={() => setUploadJobId(null)}
+        onUploaded={refresh}
+      />
+      <AssignInventoryModal
+        jobId={inventoryJobId}
+        isOpen={!!inventoryJobId}
+        onClose={() => setInventoryJobId(null)}
       />
       <h2 className="text-xl font-bold mt-8 mb-4">QA Review</h2>
       <QAReviewPanel />


### PR DESCRIPTION
## Summary
- add `UploadDocsModal` for document uploads
- add `AssignInventoryModal` for inventory assignment
- wire up new modals in install manager dashboard

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6857444b90a0832db33ce73a98002c56