### PR TITLE
Add checklist persistence

### DIFF
--- a/installer-app/src/installer/components/InstallerChecklistWizard.jsx
+++ b/installer-app/src/installer/components/InstallerChecklistWizard.jsx
@@ -1,5 +1,7 @@
 import React, { useState, useRef } from "react";
 import PropTypes from "prop-types";
+import { useChecklist } from "../../lib/hooks/useChecklist";
+import { useJobs } from "../../lib/hooks/useJobs";
 
 const inventoryList = [
   "PIR Motion Detector",
@@ -10,6 +12,8 @@ const inventoryList = [
 
 const InstallerChecklistWizard = ({ isOpen, onClose, onSubmit, job }) => {
   const [step, setStep] = useState(0);
+  const { items, toggleItem } = useChecklist(job?.id || "");
+  const { updateStatus } = useJobs();
   const [photos, setPhotos] = useState({});
   const handlePhotoUpload = (stepId, file) => {
     setPhotos((prev) => ({ ...prev, [stepId]: file }));
@@ -96,12 +100,22 @@ const InstallerChecklistWizard = ({ isOpen, onClose, onSubmit, job }) => {
     return true;
   };
 
-  const nextStep = () => {
-    if (stepValid()) setStep((prev) => prev + 1);
+  const nextStep = async () => {
+    if (!stepValid()) return;
+    const item = items[step];
+    if (item && !item.completed) {
+      await toggleItem(item.id, true);
+    }
+    setStep((prev) => prev + 1);
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!stepValid()) return;
+    const item = items[step];
+    if (item && !item.completed) {
+      await toggleItem(item.id, true);
+    }
+    if (job?.id) await updateStatus(job.id, "needs_qa");
     onSubmit({
       customerPresent,
       absenceReason,
@@ -320,7 +334,6 @@ const InstallerChecklistWizard = ({ isOpen, onClose, onSubmit, job }) => {
           </div>
         )}
 
-        {/* Update step === 2 to include step photo upload and step === 3 to remove separate photo */}
         {/* Buttons */}
         <div className="flex justify-between mt-6">
           {step > 0 ? (


### PR DESCRIPTION
## Summary
- fetch checklist items with `useChecklist`
- store checklist completion using `toggleItem`
- update job status to `needs_qa` on submit
- remove outdated comment from checklist wizard

## Testing
- `npm test --prefix installer-app` *(fails: jest not found)*
- `npm run lint --prefix installer-app` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_685743c870e0832d97cd21ef55870e11