### PR TITLE
Implement RBAC enforcement

### DIFF
--- a/installer-app/src/App.jsx
+++ b/installer-app/src/App.jsx
@@ -15,6 +15,7 @@ import InstallerDashboard from "./app/installer/InstallerDashboard";
 import InstallerJobPage from "./app/installer/jobs/JobPage";
 import ManagerReview from "./app/manager/ReviewPage";
 import LoginPage from "./app/login/LoginPage";
+import UnauthorizedPage from "./app/UnauthorizedPage";
 import { AuthProvider } from "./lib/hooks/useAuth";
 import { RequireRole as RequireRoleOutlet } from "./components/auth/RequireAuth";
 import RequireRole from "./components/RequireRole";
@@ -33,6 +34,7 @@ const App = () => (
       <Suspense fallback={<div>Loading...</div>}>
         <Routes>
           <Route path="/login" element={<LoginPage />} />
+          <Route path="/unauthorized" element={<UnauthorizedPage />} />
           <Route element={<RequireRoleOutlet role="Installer" />}>
             <Route path="/" element={<InstallerHomePage />} />
             <Route path="/appointments" element={<AppointmentSummaryPage />} />
@@ -40,15 +42,17 @@ const App = () => (
             <Route path="/ifi" element={<IFIDashboard />} />
             <Route path="/job/:jobId" element={<JobDetailPage />} />
             <Route path="/mock-jobs" element={<MockJobsPage />} />
-            <Route path="/installer/dashboard" element={<InstallerDashboard />} />
-            <Route path="/installer/jobs/:id" element={<InstallerJobPage />} />
           </Route>
-          <Route element={<RequireRoleOutlet role="Admin" />}>
-            <Route path="/admin/jobs/new" element={<AdminNewJob />} />
-            <Route path="/admin/jobs/:id" element={<AdminJobDetail />} />
+          <Route path="/installer" element={<RequireRoleOutlet role="Installer" />}>
+            <Route path="dashboard" element={<InstallerDashboard />} />
+            <Route path="jobs/:id" element={<InstallerJobPage />} />
           </Route>
-          <Route element={<RequireRoleOutlet role="Manager" />}>
-            <Route path="/manager/review" element={<ManagerReview />} />
+          <Route path="/admin" element={<RequireRoleOutlet role="Admin" />}>
+            <Route path="jobs/new" element={<AdminNewJob />} />
+            <Route path="jobs/:id" element={<AdminJobDetail />} />
+          </Route>
+          <Route path="/manager" element={<RequireRoleOutlet role="Manager" />}>
+            <Route path="review" element={<ManagerReview />} />
           </Route>
           <Route
             path="/install-manager"

--- a/installer-app/src/app/UnauthorizedPage.tsx
+++ b/installer-app/src/app/UnauthorizedPage.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+const UnauthorizedPage: React.FC = () => (
+  <div className="p-4 text-center">
+    <h1 className="text-2xl font-bold mb-2">Access Denied</h1>
+    <p>You do not have permission to view this page.</p>
+  </div>
+);
+
+export default UnauthorizedPage;

--- a/installer-app/src/app/admin/jobs/JobDetailPage.tsx
+++ b/installer-app/src/app/admin/jobs/JobDetailPage.tsx
@@ -1,14 +1,16 @@
 import React, { useState, useEffect } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, Navigate } from "react-router-dom";
 import { SZButton } from "../../../components/ui/SZButton";
 import { SZTable } from "../../../components/ui/SZTable";
 import { useJobs } from "../../../lib/hooks/useJobs";
 import { useJobMaterials } from "../../../lib/hooks/useJobMaterials";
 import { useInstallers } from "../../../lib/hooks/useInstallers";
 import supabase from "../../../lib/supabaseClient";
+import { useAuth } from "../../../lib/hooks/useAuth";
 
 const JobDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
+  const { session, isAuthorized, loading: authLoading } = useAuth();
   const { jobs, assignJob } = useJobs();
   const { items, updateUsed, addMaterial, fetchItems } = useJobMaterials(
     id || "",
@@ -21,6 +23,10 @@ const JobDetailPage: React.FC = () => {
   const [installerId, setInstallerId] = useState(job?.assigned_to || "");
   const [newMaterial, setNewMaterial] = useState("");
   const [newQty, setNewQty] = useState(1);
+
+  if (authLoading) return <p className="p-4">Loading...</p>;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized("Admin")) return <Navigate to="/unauthorized" replace />;
 
   useEffect(() => {
     async function loadMaterials() {

--- a/installer-app/src/app/admin/jobs/NewJobPage.tsx
+++ b/installer-app/src/app/admin/jobs/NewJobPage.tsx
@@ -2,13 +2,20 @@ import React, { useState } from "react";
 import { SZInput } from "../../../components/ui/SZInput";
 import { SZButton } from "../../../components/ui/SZButton";
 import { useJobs } from "../../../lib/hooks/useJobs";
+import { useAuth } from "../../../lib/hooks/useAuth";
+import { Navigate } from "react-router-dom";
 
 const NewJobPage: React.FC = () => {
+  const { session, isAuthorized, loading: authLoading } = useAuth();
   const { createJob } = useJobs();
   const [clinic, setClinic] = useState("");
   const [contact, setContact] = useState("");
   const [phone, setPhone] = useState("");
   const [loading, setLoading] = useState(false);
+
+  if (authLoading) return <p className="p-4">Loading...</p>;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized("Admin")) return <Navigate to="/unauthorized" replace />;
 
   const handleCreate = async () => {
     setLoading(true);

--- a/installer-app/src/app/clients/ClientsPage.tsx
+++ b/installer-app/src/app/clients/ClientsPage.tsx
@@ -3,13 +3,21 @@ import { SZButton } from "../../components/ui/SZButton";
 import { SZTable } from "../../components/ui/SZTable";
 import ClientFormModal, { Client } from "../../components/modals/ClientFormModal";
 import useClinics from "../../lib/hooks/useClinics";
+import { useAuth } from "../../lib/hooks/useAuth";
+import { Navigate } from "react-router-dom";
 
 
 const ClientsPage: React.FC = () => {
+  const { session, isAuthorized, loading: authLoading } = useAuth();
   const [clients, { loading, error, createClinic, updateClinic, deleteClinic }] =
     useClinics();
   const [active, setActive] = useState<Client | null>(null);
   const [open, setOpen] = useState(false);
+
+  if (authLoading) return <p className="p-4">Loading...</p>;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized("Manager") && !isAuthorized("Admin"))
+    return <Navigate to="/unauthorized" replace />;
 
   const handleSave = async (data: Client) => {
     try {

--- a/installer-app/src/app/install-manager/job/NewJobBuilderPage.tsx
+++ b/installer-app/src/app/install-manager/job/NewJobBuilderPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Navigate } from "react-router-dom";
+import { useAuth } from "../../../lib/hooks/useAuth";
 import { SZInput } from "../../../components/ui/SZInput";
 import { SZButton } from "../../../components/ui/SZButton";
 import supabase from "../../../lib/supabaseClient";
@@ -30,12 +31,18 @@ const initialJob = {
 
 const NewJobBuilderPage: React.FC = () => {
   const navigate = useNavigate();
+  const { session, isAuthorized, loading } = useAuth();
   const [job, setJob] = useState(initialJob);
   const [materials, setMaterials] = useState<Material[]>([]);
   const [rows, setRows] = useState<MaterialRow[]>([
     { material_id: "", quantity: 1, sale_price: "", install_location: "" },
   ]);
   const [submitting, setSubmitting] = useState(false);
+
+  if (loading) return <p>Loading...</p>;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized("Manager") && !isAuthorized("Admin"))
+    return <Navigate to="/unauthorized" replace />;
 
   useEffect(() => {
     const fetchMaterials = async () => {

--- a/installer-app/src/app/install-manager/page.jsx
+++ b/installer-app/src/app/install-manager/page.jsx
@@ -6,13 +6,20 @@ import { useJobs } from "./useJobs";
 import EditJobModal from "./EditJobModal";
 import ConfirmDeleteModal from "./ConfirmDeleteModal";
 import QAReviewPanel from "./QAReviewPanel";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Navigate } from "react-router-dom";
+import { useAuth } from "../../lib/hooks/useAuth";
 
 export default function InstallManagerDashboard() {
-  const { jobs, loading, error, refresh } = useJobs();
+  const { session, isAuthorized, loading: authLoading } = useAuth();
+  const { jobs, loading: jobsLoading, error, refresh } = useJobs();
   const navigate = useNavigate();
   const [editJob, setEditJob] = useState(null);
   const [deleteJob, setDeleteJob] = useState(null);
+
+  if (authLoading) return <p>Loading...</p>;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized("Manager") && !isAuthorized("Admin"))
+    return <Navigate to="/unauthorized" replace />;
 
   const handleView = (id) => console.log("view", id);
   const handleEdit = (job) => setEditJob(job);
@@ -27,7 +34,7 @@ export default function InstallManagerDashboard() {
           New Job
         </SZButton>
       </header>
-      {loading && <div>Loading...</div>}
+      {jobsLoading && <div>Loading...</div>}
       {error && <div className="text-red-600">{error}</div>}
       <ul className="space-y-4">
         {jobs.map((job) => {

--- a/installer-app/src/app/installer/InstallerDashboard.tsx
+++ b/installer-app/src/app/installer/InstallerDashboard.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, Navigate } from "react-router-dom";
 import { useJobs } from "../../lib/hooks/useJobs";
 import { useAuth } from "../../lib/hooks/useAuth";
 
 const InstallerDashboard: React.FC = () => {
-  const { session } = useAuth();
+  const { session, isAuthorized, loading: authLoading } = useAuth();
   const currentUserId = session?.user?.id;
   const { jobs, loading } = useJobs();
   const myJobs = jobs.filter(
@@ -13,6 +13,9 @@ const InstallerDashboard: React.FC = () => {
       j.assigned_to === currentUserId,
   );
 
+  if (authLoading) return <p className="p-4">Loading...</p>;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized("Installer")) return <Navigate to="/unauthorized" replace />;
   if (loading) return <p className="p-4">Loading...</p>;
 
   return (

--- a/installer-app/src/app/installer/jobs/JobPage.tsx
+++ b/installer-app/src/app/installer/jobs/JobPage.tsx
@@ -1,18 +1,24 @@
 import React from "react";
-import { useParams } from "react-router-dom";
+import { useParams, Navigate } from "react-router-dom";
 import { SZButton } from "../../../components/ui/SZButton";
 import SZChecklist from "../../../components/ui/SZChecklist";
 import { useJobs } from "../../../lib/hooks/useJobs";
 import { useChecklist } from "../../../lib/hooks/useChecklist";
 import { useJobMaterials } from "../../../lib/hooks/useJobMaterials";
 import { SZTable } from "../../../components/ui/SZTable";
+import { useAuth } from "../../../lib/hooks/useAuth";
 
 const JobPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
+  const { session, isAuthorized, loading: authLoading } = useAuth();
   const { jobs, updateStatus } = useJobs();
   const { items, toggleItem } = useChecklist(id || "");
   const { items: mats, updateUsed } = useJobMaterials(id || "");
   const job = jobs.find((j) => j.id === id);
+
+  if (authLoading) return <p className="p-4">Loading...</p>;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized("Installer")) return <Navigate to="/unauthorized" replace />;
 
   if (!job) return <p className="p-4">Job not found</p>;
 

--- a/installer-app/src/app/invoices/InvoicesPage.tsx
+++ b/installer-app/src/app/invoices/InvoicesPage.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import { SZButton } from "../../components/ui/SZButton";
 import { SZTable } from "../../components/ui/SZTable";
+import { useAuth } from "../../lib/hooks/useAuth";
+import { Navigate } from "react-router-dom";
 
 interface Invoice {
   id: string;
@@ -15,6 +17,7 @@ const initialInvoices: Invoice[] = [
 ];
 
 const InvoicesPage: React.FC = () => {
+  const { session, isAuthorized, loading: authLoading } = useAuth();
   const [invoices, setInvoices] = useState<Invoice[]>(initialInvoices);
   const [filter, setFilter] = useState<"all" | "paid" | "unpaid">("all");
 
@@ -23,6 +26,11 @@ const InvoicesPage: React.FC = () => {
       inv.map((i) => (i.id === id ? { ...i, status: "paid" } : i)),
     );
   };
+
+  if (authLoading) return <p className="p-4">Loading...</p>;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized("Manager") && !isAuthorized("Admin"))
+    return <Navigate to="/unauthorized" replace />;
 
   const filtered = invoices.filter((i) =>
     filter === "all" ? true : i.status === filter,

--- a/installer-app/src/app/manager/ReviewPage.tsx
+++ b/installer-app/src/app/manager/ReviewPage.tsx
@@ -1,14 +1,21 @@
 import React from "react";
 import { SZButton } from "../../components/ui/SZButton";
 import { useJobs } from "../../lib/hooks/useJobs";
+import { useAuth } from "../../lib/hooks/useAuth";
+import { Navigate } from "react-router-dom";
 
 const ReviewPage: React.FC = () => {
+  const { session, isAuthorized, loading: authLoading } = useAuth();
   const { jobs, updateStatus } = useJobs();
   const submitted = jobs.filter((j) => j.status === "submitted");
 
   const handleComplete = async (id: string) => {
     await updateStatus(id, "complete");
   };
+
+  if (authLoading) return <p className="p-4">Loading...</p>;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized("Manager")) return <Navigate to="/unauthorized" replace />;
 
   return (
     <div className="p-4 space-y-4">

--- a/installer-app/src/app/messages/MessagesPanel.tsx
+++ b/installer-app/src/app/messages/MessagesPanel.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import { SZButton } from "../../components/ui/SZButton";
 import { SZInput } from "../../components/ui/SZInput";
+import { useAuth } from "../../lib/hooks/useAuth";
+import { Navigate } from "react-router-dom";
 
 interface Message {
   id: string;
@@ -28,8 +30,14 @@ const initialMessages: Message[] = [
 ];
 
 const MessagesPanel: React.FC = () => {
+  const { session, isAuthorized, loading: authLoading } = useAuth();
   const [messages, setMessages] = useState<Message[]>(initialMessages);
   const [text, setText] = useState("");
+
+  if (authLoading) return <p className="p-4">Loading...</p>;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized("Manager") && !isAuthorized("Admin"))
+    return <Navigate to="/unauthorized" replace />;
 
   const send = () => {
     if (!text.trim()) return;

--- a/installer-app/src/app/payments/PaymentsPage.tsx
+++ b/installer-app/src/app/payments/PaymentsPage.tsx
@@ -3,6 +3,8 @@ import { SZButton } from "../../components/ui/SZButton";
 import { SZInput } from "../../components/ui/SZInput";
 import { SZTable } from "../../components/ui/SZTable";
 import ModalWrapper from "../../installer/components/ModalWrapper";
+import { useAuth } from "../../lib/hooks/useAuth";
+import { Navigate } from "react-router-dom";
 
 interface Payment {
   id: string;
@@ -25,6 +27,7 @@ const initialPayments: Payment[] = [
 const invoices = ["INV-1", "INV-2"];
 
 const PaymentsPage: React.FC = () => {
+  const { session, isAuthorized, loading: authLoading } = useAuth();
   const [payments, setPayments] = useState<Payment[]>(initialPayments);
   const [open, setOpen] = useState(false);
   const [form, setForm] = useState({
@@ -32,6 +35,11 @@ const PaymentsPage: React.FC = () => {
     amount: "",
     method: "",
   });
+
+  if (authLoading) return <p className="p-4">Loading...</p>;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized("Manager") && !isAuthorized("Admin"))
+    return <Navigate to="/unauthorized" replace />;
 
   const handleSave = () => {
     setPayments((ps) => [

--- a/installer-app/src/app/quotes/QuotesPage.tsx
+++ b/installer-app/src/app/quotes/QuotesPage.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from "react";
 import { SZButton } from "../../components/ui/SZButton";
 import { SZTable } from "../../components/ui/SZTable";
-import QuoteFormModal, {
-  QuoteData,
-} from "../../components/modals/QuoteFormModal";
+import QuoteFormModal, { QuoteData } from "../../components/modals/QuoteFormModal";
+import { useAuth } from "../../lib/hooks/useAuth";
+import { Navigate } from "react-router-dom";
 
 const initialQuotes: QuoteData[] = [
   { id: "1", client: "Acme Clinic", lines: [], total: 1500 },
@@ -11,6 +11,7 @@ const initialQuotes: QuoteData[] = [
 ];
 
 const QuotesPage: React.FC = () => {
+  const { session, isAuthorized, loading: authLoading } = useAuth();
   const [quotes, setQuotes] = useState(
     initialQuotes.map((q) => ({ ...q, status: "pending" })) as (QuoteData & {
       status: string;
@@ -20,6 +21,11 @@ const QuotesPage: React.FC = () => {
     (QuoteData & { status?: string }) | null
   >(null);
   const [open, setOpen] = useState(false);
+
+  if (authLoading) return <p className="p-4">Loading...</p>;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized("Manager") && !isAuthorized("Admin"))
+    return <Navigate to="/unauthorized" replace />;
 
   const handleSave = (data: QuoteData) => {
     if (data.id) {

--- a/installer-app/src/app/reports/ReportsPage.tsx
+++ b/installer-app/src/app/reports/ReportsPage.tsx
@@ -1,12 +1,20 @@
 import React from "react";
 import { SZTable } from "../../components/ui/SZTable";
+import { useAuth } from "../../lib/hooks/useAuth";
+import { Navigate } from "react-router-dom";
 
 const ReportsPage: React.FC = () => {
+  const { session, isAuthorized, loading: authLoading } = useAuth();
   const metrics = [
     { label: "Total Jobs", value: 42 },
     { label: "Revenue", value: "$12,000" },
     { label: "Avg Job Size", value: "$300" },
   ];
+
+  if (authLoading) return <p className="p-4">Loading...</p>;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized("Manager") && !isAuthorized("Admin"))
+    return <Navigate to="/unauthorized" replace />;
 
   return (
     <div className="p-4 space-y-4">

--- a/installer-app/src/app/time-tracking/TimeTrackingPanel.tsx
+++ b/installer-app/src/app/time-tracking/TimeTrackingPanel.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import { SZButton } from "../../components/ui/SZButton";
 import { SZTable } from "../../components/ui/SZTable";
+import { useAuth } from "../../lib/hooks/useAuth";
+import { Navigate } from "react-router-dom";
 
 interface Log {
   id: string;
@@ -10,9 +12,15 @@ interface Log {
 }
 
 const TimeTrackingPanel: React.FC = () => {
+  const { session, isAuthorized, loading: authLoading } = useAuth();
   const [clockedIn, setClockedIn] = useState(false);
   const [start, setStart] = useState<number | null>(null);
   const [logs, setLogs] = useState<Log[]>([]);
+
+  if (authLoading) return <p className="p-4">Loading...</p>;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized("Manager") && !isAuthorized("Admin"))
+    return <Navigate to="/unauthorized" replace />;
 
   const toggleClock = () => {
     if (clockedIn) {

--- a/installer-app/src/installer/pages/ActivitySummaryPage.jsx
+++ b/installer-app/src/installer/pages/ActivitySummaryPage.jsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 import { FaSyncAlt } from 'react-icons/fa';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Navigate } from 'react-router-dom';
+import { useAuth } from '../../lib/hooks/useAuth';
 import Header from '../components/Header';
 import SideDrawer from '../components/SideDrawer';
 
 const ActivitySummaryPage = () => {
   const [showDrawer, setShowDrawer] = useState(false);
+  const { session, isAuthorized, loading } = useAuth();
 
   const withdrawals = [
     {
@@ -17,6 +19,10 @@ const ActivitySummaryPage = () => {
       ],
     },
   ];
+
+  if (loading) return null;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized('Installer')) return <Navigate to="/unauthorized" replace />;
 
   const navigate = useNavigate();
   const handleDrawerOpen = () => setShowDrawer(true);

--- a/installer-app/src/installer/pages/AppointmentSummaryPage.jsx
+++ b/installer-app/src/installer/pages/AppointmentSummaryPage.jsx
@@ -7,7 +7,8 @@ import {
   FaTimesCircle,
   FaRegCircle,
 } from 'react-icons/fa';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Navigate } from 'react-router-dom';
+import { useAuth } from '../../lib/hooks/useAuth';
 import Header from '../components/Header';
 import SideDrawer from '../components/SideDrawer';
 import { useAppointments } from '../hooks/useInstallerData';
@@ -16,9 +17,14 @@ const AppointmentSummaryPage = ({ jobs }) => {
   const [showDrawer, setShowDrawer] = useState(false);
   const [showInfo, setShowInfo] = useState(false);
   const navigate = useNavigate();
+  const { session, isAuthorized, loading: authLoading } = useAuth();
 
   const { appointments, loading, error } = useAppointments();
   const data = jobs || appointments;
+
+  if (authLoading) return null;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized('Installer')) return <Navigate to="/unauthorized" replace />;
 
   const handleDrawerOpen = () => setShowDrawer(true);
   const handleDrawerClose = () => setShowDrawer(false);

--- a/installer-app/src/installer/pages/FeedbackPage.jsx
+++ b/installer-app/src/installer/pages/FeedbackPage.jsx
@@ -2,9 +2,16 @@ import React, { useState } from 'react';
 import Header from '../components/Header';
 import SideDrawer from '../components/SideDrawer';
 import InstallerFeedbackForm from '../components/InstallerFeedbackForm';
+import { useAuth } from '../../lib/hooks/useAuth';
+import { Navigate } from 'react-router-dom';
 
 const FeedbackPage = () => {
   const [showDrawer, setShowDrawer] = useState(false);
+  const { session, isAuthorized, loading } = useAuth();
+
+  if (loading) return null;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized('Installer')) return <Navigate to="/unauthorized" replace />;
 
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col relative">

--- a/installer-app/src/installer/pages/IFIDashboard.jsx
+++ b/installer-app/src/installer/pages/IFIDashboard.jsx
@@ -1,9 +1,16 @@
 import React from 'react';
 import { useIFIScores } from '../hooks/useInstallerData';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../../lib/hooks/useAuth';
 
 
 const IFIDashboard = () => {
+  const { session, isAuthorized, loading: authLoading } = useAuth();
   const { data, loading } = useIFIScores();
+
+  if (authLoading) return <div className="p-4 text-center">Loading...</div>;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized('Installer')) return <Navigate to="/unauthorized" replace />;
 
   if (loading || !data) {
     return <div className="p-4 text-center">Loading...</div>;

--- a/installer-app/src/installer/pages/InstallerHomePage.jsx
+++ b/installer-app/src/installer/pages/InstallerHomePage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { FaSyncAlt, FaBriefcase, FaClock } from "react-icons/fa";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Navigate } from "react-router-dom";
+import { useAuth } from "../../lib/hooks/useAuth";
 import Header from "../components/Header";
 import SideDrawer from "../components/SideDrawer";
 import OpenManagerPreview from "../components/OpenManagerPreview";
@@ -11,10 +12,15 @@ const InstallerHomePage = ({
 }) => {
   const [showDrawer, setShowDrawer] = useState(false);
   const navigate = useNavigate();
+  const { session, isAuthorized, loading } = useAuth();
   const handleDrawer = () => setShowDrawer(true);
   const handleRefresh = () => navigate(0);
   const handleAppointmentSummary = () => navigate("/appointments");
   const handleActivitySummary = () => navigate("/activity");
+
+  if (loading) return null;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized("Installer")) return <Navigate to="/unauthorized" replace />;
 
   return (
     <div className="bg-gray-100 flex flex-col min-h-screen relative">

--- a/installer-app/src/installer/pages/JobDetailPage.jsx
+++ b/installer-app/src/installer/pages/JobDetailPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, Navigate } from "react-router-dom";
 import InstallerChecklistWizard from "../components/InstallerChecklistWizard";
-import useInstallerAuth from "../hooks/useInstallerAuth";
+import { useAuth } from "../../lib/hooks/useAuth";
 import DocumentViewerModal from "../components/DocumentViewerModal";
 import Header from "../components/Header";
 import SideDrawer from "../components/SideDrawer";
@@ -15,7 +15,12 @@ const JobDetailPage = () => {
   const [showDocuments, setShowDocuments] = useState(false);
   const startTimeRef = useRef(Date.now());
 
-  const { installerId } = useInstallerAuth();
+  const { session, isAuthorized, loading } = useAuth();
+  const installerId = session?.user?.id || "";
+
+  if (loading) return null;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized("Installer")) return <Navigate to="/unauthorized" replace />;
 
   const isTest = process.env.NODE_ENV === "test";
   const sampleJobs = isTest

--- a/installer-app/src/installer/pages/MockJobsPage.jsx
+++ b/installer-app/src/installer/pages/MockJobsPage.jsx
@@ -1,28 +1,36 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, Navigate } from 'react-router-dom';
+import { useAuth } from '../../lib/hooks/useAuth';
 import Header from '../components/Header';
 
 const jobs = ['SEA1001', 'SEA1002', 'SEA1003', 'SEA1004', 'SEA1024'];
 
-const MockJobsPage = () => (
-  <div className="min-h-screen bg-gray-100 flex flex-col">
-    <Header title="Mock Jobs" />
-    <main className="flex-grow p-4">
-      <h1 className="text-2xl font-bold text-center mb-4">Select a Job</h1>
-      <ul className="space-y-2 max-w-sm mx-auto">
-        {jobs.map((job) => (
-          <li key={job}>
-            <Link
-              to={`/job/${job}`}
-              className="block bg-white rounded shadow px-4 py-2 text-green-600 hover:bg-gray-50 text-center"
-            >
-              {job}
-            </Link>
-          </li>
-        ))}
-      </ul>
-    </main>
-  </div>
-);
+const MockJobsPage = () => {
+  const { session, isAuthorized, loading } = useAuth();
+  if (loading) return null;
+  if (!session) return <Navigate to="/login" replace />;
+  if (!isAuthorized('Installer')) return <Navigate to="/unauthorized" replace />;
+
+  return (
+    <div className="min-h-screen bg-gray-100 flex flex-col">
+      <Header title="Mock Jobs" />
+      <main className="flex-grow p-4">
+        <h1 className="text-2xl font-bold text-center mb-4">Select a Job</h1>
+        <ul className="space-y-2 max-w-sm mx-auto">
+          {jobs.map((job) => (
+            <li key={job}>
+              <Link
+                to={`/job/${job}`}
+                className="block bg-white rounded shadow px-4 py-2 text-green-600 hover:bg-gray-50 text-center"
+              >
+                {job}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </main>
+    </div>
+  );
+};
 
 export default MockJobsPage;

--- a/installer-app/src/lib/hooks/useAuth.tsx
+++ b/installer-app/src/lib/hooks/useAuth.tsx
@@ -4,6 +4,7 @@ type AuthContextType = {
   session: any;
   role: string | null;
   loading: boolean;
+  isAuthorized: (role: string) => boolean;
 };
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -26,8 +27,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     init();
   }, []);
 
+  const isAuthorized = (r: string) => role === r;
+
   return (
-    <AuthContext.Provider value={{ session, role, loading }}>
+    <AuthContext.Provider value={{ session, role, loading, isAuthorized }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- expand `useAuth` to provide `isAuthorized` helper
- add UnauthorizedPage and route
- wrap installer/admin/manager routes under `RequireRole` outlets
- enforce role checks inside all route components

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6857427865a0832dae46f0b1b63113af