### PR TITLE
Add global archived jobs viewer

### DIFF
--- a/installer-app/api/migrations/005_create_checklists.sql
+++ b/installer-app/api/migrations/005_create_checklists.sql
@@ -1,0 +1,7 @@
+create table if not exists checklists (
+  id uuid primary key default uuid_generate_v4(),
+  job_id uuid references jobs(id) on delete cascade,
+  completed boolean default false,
+  responses jsonb,
+  created_at timestamptz not null default now()
+);

--- a/installer-app/api/migrations/006_create_profiles.sql
+++ b/installer-app/api/migrations/006_create_profiles.sql
@@ -1,0 +1,17 @@
+create table if not exists profiles (
+  user_id uuid references auth.users(id) primary key,
+  phone text,
+  avatar_url text,
+  updated_at timestamptz not null default now()
+);
+
+alter table profiles enable row level security;
+
+create policy "Profiles Select" on profiles
+  for select using (auth.uid() = user_id);
+
+create policy "Profiles Insert" on profiles
+  for insert with check (auth.uid() = user_id);
+
+create policy "Profiles Update" on profiles
+  for update using (auth.uid() = user_id);

--- a/installer-app/api/migrations/007_jobs_rls.sql
+++ b/installer-app/api/migrations/007_jobs_rls.sql
@@ -1,0 +1,16 @@
+alter table jobs enable row level security;
+
+create policy "Jobs Select Assigned" on jobs
+  for select using (
+    assigned_to = auth.uid()
+    or exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager'))
+  );
+
+create policy "Jobs Update Assigned" on jobs
+  for update using (
+    assigned_to = auth.uid()
+    or exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager'))
+  );
+
+create policy "Jobs Insert" on jobs
+  for insert with check (true);

--- a/installer-app/api/migrations/008_create_job_materials_used.sql
+++ b/installer-app/api/migrations/008_create_job_materials_used.sql
@@ -1,0 +1,27 @@
+create table if not exists job_materials_used (
+  id uuid primary key default uuid_generate_v4(),
+  job_id uuid references jobs(id) on delete cascade,
+  material_id uuid references materials(id),
+  quantity int not null,
+  installer_id uuid references auth.users(id),
+  photo_url text,
+  created_at timestamptz default now()
+);
+
+alter table job_materials_used enable row level security;
+
+create policy "JobMaterialsUsed Select" on job_materials_used
+  for select using (
+    installer_id = auth.uid()
+    or exists (
+      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager')
+    )
+  );
+
+create policy "JobMaterialsUsed Insert" on job_materials_used
+  for insert with check (
+    installer_id = auth.uid() and
+    exists (
+      select 1 from jobs where id = job_id and assigned_to = auth.uid()
+    )
+  );

--- a/installer-app/api/migrations/009_create_qa_reviews.sql
+++ b/installer-app/api/migrations/009_create_qa_reviews.sql
@@ -1,0 +1,24 @@
+create table if not exists qa_reviews (
+  id uuid primary key default uuid_generate_v4(),
+  job_id uuid references jobs(id) on delete cascade,
+  reviewer_id uuid references auth.users(id),
+  decision text not null check (decision in ('approved','rework')),
+  notes text,
+  created_at timestamptz not null default now()
+);
+
+alter table qa_reviews enable row level security;
+
+create policy "QAReviews Select" on qa_reviews
+  for select using (
+    exists (
+      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager')
+    )
+  );
+
+create policy "QAReviews Insert" on qa_reviews
+  for insert with check (
+    exists (
+      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager')
+    )
+  );

--- a/installer-app/api/migrations/010_update_job_statuses.sql
+++ b/installer-app/api/migrations/010_update_job_statuses.sql
@@ -1,0 +1,4 @@
+alter table jobs drop constraint if exists jobs_status_check;
+alter table jobs
+  add constraint jobs_status_check
+  check (status in ('created','assigned','in_progress','needs_qa','complete','rework'));

--- a/installer-app/api/migrations/011_create_job_with_materials_function.sql
+++ b/installer-app/api/migrations/011_create_job_with_materials_function.sql
@@ -1,0 +1,25 @@
+create or replace function create_job_with_materials(
+  p_clinic_name text,
+  p_address text,
+  p_start_time date,
+  p_installer uuid,
+  p_materials jsonb
+) returns uuid as $$
+declare
+  new_job_id uuid;
+begin
+  insert into jobs (clinic_name, address, scheduled_date, assigned_to, status)
+  values (p_clinic_name, p_address, p_start_time, p_installer, 'assigned')
+  returning id into new_job_id;
+
+  if p_materials is not null then
+    insert into job_materials (job_id, material_id, quantity)
+    select new_job_id,
+           (m->>'material_id')::uuid,
+           (m->>'quantity')::int
+    from jsonb_array_elements(p_materials) as m;
+  end if;
+
+  return new_job_id;
+end;
+$$ language plpgsql;

--- a/installer-app/api/migrations/012_update_job_statuses_archived.sql
+++ b/installer-app/api/migrations/012_update_job_statuses_archived.sql
@@ -1,0 +1,4 @@
+alter table jobs drop constraint if exists jobs_status_check;
+alter table jobs
+  add constraint jobs_status_check
+  check (status in ('created','assigned','in_progress','needs_qa','complete','rework','archived'));

--- a/installer-app/src/App.jsx
+++ b/installer-app/src/App.jsx
@@ -1,19 +1,21 @@
 import React, { Suspense, lazy } from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import InstallerHomePage from "./installer/pages/InstallerHomePage";
-import AppointmentSummaryPage from "./installer/pages/AppointmentSummaryPage";
-import ActivitySummaryPage from "./installer/pages/ActivitySummaryPage";
+import InstallerAppointmentPage from "./app/appointments/InstallerAppointmentPage";
+import ActivityLogPage from "./app/activity/ActivityLogPage";
 import JobDetailPage from "./installer/pages/JobDetailPage";
 import IFIDashboard from "./installer/pages/IFIDashboard";
 import MockJobsPage from "./installer/pages/MockJobsPage";
 import FeedbackPage from "./installer/pages/FeedbackPage";
 import InstallManagerDashboard from "./app/install-manager/page.jsx";
 import NewJobBuilderPage from "./app/install-manager/job/NewJobBuilderPage";
-import AdminNewJob from "./app/admin/jobs/NewJobPage";
+import AdminNewJob from "./app/admin/jobs/AdminNewJob";
 import AdminJobDetail from "./app/admin/jobs/JobDetailPage";
 import InstallerDashboard from "./app/installer/InstallerDashboard";
-import InstallerJobPage from "./app/installer/jobs/JobPage";
-import ManagerReview from "./app/manager/ReviewPage";
+import InstallerJobPage from "./app/installer/jobs/InstallerJobPage";
+import InstallerProfilePage from "./app/installer/profile/InstallerProfilePage";
+import ManagerReview from "./app/manager/ManagerReview";
+import ArchivedJobsPage from "./app/archived/ArchivedJobsPage";
 import LoginPage from "./app/login/LoginPage";
 import { AuthProvider } from "./lib/hooks/useAuth";
 import { RequireRole as RequireRoleOutlet } from "./components/auth/RequireAuth";
@@ -37,13 +39,15 @@ const App = () => (
 
           <Route element={<RequireRoleOutlet role="Installer" />}>
             <Route path="/" element={<InstallerHomePage />} />
-            <Route path="/appointments" element={<AppointmentSummaryPage />} />
-            <Route path="/activity" element={<ActivitySummaryPage />} />
+            <Route path="/appointments" element={<InstallerAppointmentPage />} />
+            <Route path="/activity" element={<ActivityLogPage />} />
             <Route path="/ifi" element={<IFIDashboard />} />
             <Route path="/job/:jobId" element={<JobDetailPage />} />
             <Route path="/mock-jobs" element={<MockJobsPage />} />
+            <Route path="/installer" element={<InstallerDashboard />} />
             <Route path="/installer/dashboard" element={<InstallerDashboard />} />
             <Route path="/installer/jobs/:id" element={<InstallerJobPage />} />
+            <Route path="/installer/profile" element={<InstallerProfilePage />} />
           </Route>
 
           <Route element={<RequireRoleOutlet role="Admin" />}>
@@ -51,9 +55,26 @@ const App = () => (
             <Route path="/admin/jobs/:id" element={<AdminJobDetail />} />
           </Route>
 
-          <Route element={<RequireRoleOutlet role="Manager" />}>
-            <Route path="/manager/review" element={<ManagerReview />} />
-          </Route>
+        <Route element={<RequireRoleOutlet role="Manager" />}>
+          <Route path="/manager/review" element={<ManagerReview />} />
+        </Route>
+
+        <Route
+          path="/manager/archived"
+          element={
+            <RequireRole role={["Manager", "Admin"]}>
+              <ArchivedJobsPage />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="/archived"
+          element={
+            <RequireRole role={["Manager", "Admin"]}>
+              <ArchivedJobsPage />
+            </RequireRole>
+          }
+        />
 
           <Route
             path="/install-manager"

--- a/installer-app/src/app/activity/ActivityLogPage.tsx
+++ b/installer-app/src/app/activity/ActivityLogPage.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from "react";
+import { SZTable } from "../../components/ui/SZTable";
+import { SZInput } from "../../components/ui/SZInput";
+import { useAuth } from "../../lib/hooks/useAuth";
+import useActivityLog from "../../lib/hooks/useActivityLog";
+import JobStatusBadge from "../../components/JobStatusBadge";
+
+const ActivityLogPage: React.FC = () => {
+  const { session } = useAuth();
+  const userId = session?.user?.id ?? null;
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+
+  const { jobs, loading } = useActivityLog(
+    userId,
+    startDate || undefined,
+    endDate || undefined,
+  );
+
+  const formatDate = (iso: string) =>
+    new Date(iso).toLocaleDateString();
+
+  const formatDuration = (start: string, end?: string | null) => {
+    if (!end) return "-";
+    const ms = new Date(end).getTime() - new Date(start).getTime();
+    const mins = Math.round(ms / 60000);
+    const hrs = Math.floor(mins / 60);
+    const rem = mins % 60;
+    return hrs > 0 ? `${hrs}h ${rem}m` : `${rem}m`;
+  };
+
+  if (loading) return <p className="p-4">Loading...</p>;
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Activity Log</h1>
+      <div className="flex gap-4">
+        <SZInput
+          id="start_date"
+          type="date"
+          label="Start Date"
+          value={startDate}
+          onChange={setStartDate}
+        />
+        <SZInput
+          id="end_date"
+          type="date"
+          label="End Date"
+          value={endDate}
+          onChange={setEndDate}
+        />
+      </div>
+      {jobs.length === 0 ? (
+        <p>No jobs found.</p>
+      ) : (
+        <SZTable
+          headers={["Job ID", "Client", "Date Completed", "Duration", "Status"]}
+        >
+          {jobs.map((j) => (
+            <tr key={j.id} className="border-t">
+              <td className="p-2 border">{j.id}</td>
+              <td className="p-2 border">{j.clinic_name}</td>
+              <td className="p-2 border">
+                {j.completed_at ? formatDate(j.completed_at) : "-"}
+              </td>
+              <td className="p-2 border">
+                {formatDuration(j.created_at, j.completed_at)}
+              </td>
+              <td className="p-2 border">
+                <JobStatusBadge status={j.status as any} />
+              </td>
+            </tr>
+          ))}
+        </SZTable>
+      )}
+    </div>
+  );
+};
+
+export default ActivityLogPage;

--- a/installer-app/src/app/admin/jobs/AdminNewJob.tsx
+++ b/installer-app/src/app/admin/jobs/AdminNewJob.tsx
@@ -1,0 +1,162 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { SZInput } from "../../../components/ui/SZInput";
+import { SZButton } from "../../../components/ui/SZButton";
+import { SZTable } from "../../../components/ui/SZTable";
+import useClinics from "../../../lib/hooks/useClinics";
+import useInstallers from "../../../lib/hooks/useInstallers";
+import useMaterials from "../../../lib/hooks/useMaterials";
+import supabase from "../../../lib/supabaseClient";
+
+interface MaterialRow {
+  material_id: string;
+  quantity: number;
+}
+
+const AdminNewJob: React.FC = () => {
+  const navigate = useNavigate();
+  const [clinics] = useClinics();
+  const { installers } = useInstallers();
+  const { materials } = useMaterials();
+
+  const [clinicId, setClinicId] = useState("");
+  const [address, setAddress] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [installerId, setInstallerId] = useState("");
+  const [rows, setRows] = useState<MaterialRow[]>([{ material_id: "", quantity: 1 }]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleRowChange = (idx: number, key: keyof MaterialRow, value: any) => {
+    setRows((rs) => rs.map((r, i) => (i === idx ? { ...r, [key]: value } : r)));
+  };
+
+  const addRow = () => setRows((rs) => [...rs, { material_id: "", quantity: 1 }]);
+  const removeRow = (idx: number) => setRows((rs) => rs.filter((_, i) => i !== idx));
+
+  const handleSubmit = async () => {
+    if (!clinicId || !address || !startDate || !installerId) {
+      setError("All fields are required");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const clinic = clinics.find((c) => c.id === clinicId);
+      const materialsData = rows
+        .filter((r) => r.material_id)
+        .map((r) => ({ material_id: r.material_id, quantity: r.quantity }));
+      const { data, error } = await supabase.rpc("create_job_with_materials", {
+        p_clinic_name: clinic?.name ?? "",
+        p_address: address,
+        p_start_time: startDate,
+        p_installer: installerId,
+        p_materials: materialsData,
+      });
+      if (error) throw error;
+      if (data) navigate(`/admin/jobs/${data}`);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Create Job</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label htmlFor="clinic" className="block text-sm font-medium text-gray-700">
+            Clinic
+          </label>
+          <select
+            id="clinic"
+            className="border rounded px-3 py-2 w-full"
+            value={clinicId}
+            onChange={(e) => setClinicId(e.target.value)}
+          >
+            <option value="">Select</option>
+            {clinics.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <SZInput id="address" label="Address" value={address} onChange={setAddress} />
+        <SZInput
+          id="startDate"
+          label="Start Date"
+          type="date"
+          value={startDate}
+          onChange={setStartDate}
+        />
+        <div>
+          <label htmlFor="installer" className="block text-sm font-medium text-gray-700">
+            Installer
+          </label>
+          <select
+            id="installer"
+            className="border rounded px-3 py-2 w-full"
+            value={installerId}
+            onChange={(e) => setInstallerId(e.target.value)}
+          >
+            <option value="">Select</option>
+            {installers.map((i) => (
+              <option key={i.id} value={i.id}>
+                {i.full_name || i.id}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <h2 className="text-xl font-semibold">Materials</h2>
+      <SZTable headers={["Product", "Qty", ""]}>
+        {rows.map((r, idx) => (
+          <tr key={idx} className="border-t">
+            <td className="p-2 border">
+              <select
+                className="border rounded px-2 py-1 w-full"
+                value={r.material_id}
+                onChange={(e) => handleRowChange(idx, "material_id", e.target.value)}
+              >
+                <option value="">Select</option>
+                {materials.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.name}
+                  </option>
+                ))}
+              </select>
+            </td>
+            <td className="p-2 border">
+              <input
+                type="number"
+                min={1}
+                className="border rounded px-2 py-1 w-24"
+                value={r.quantity}
+                onChange={(e) => handleRowChange(idx, "quantity", Number(e.target.value))}
+              />
+            </td>
+            <td className="p-2 border text-center">
+              <button type="button" className="text-red-600" onClick={() => removeRow(idx)}>
+                X
+              </button>
+            </td>
+          </tr>
+        ))}
+      </SZTable>
+      <SZButton variant="secondary" size="sm" onClick={addRow}>
+        Add Material
+      </SZButton>
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+      <div>
+        <SZButton onClick={handleSubmit} isLoading={submitting}>
+          Create Job
+        </SZButton>
+      </div>
+    </div>
+  );
+};
+
+export default AdminNewJob;

--- a/installer-app/src/app/admin/jobs/JobDetailPage.tsx
+++ b/installer-app/src/app/admin/jobs/JobDetailPage.tsx
@@ -6,10 +6,11 @@ import { useJobs } from "../../../lib/hooks/useJobs";
 import { useJobMaterials } from "../../../lib/hooks/useJobMaterials";
 import { useInstallers } from "../../../lib/hooks/useInstallers";
 import supabase from "../../../lib/supabaseClient";
+import UploadClosingPackage from "../../../components/UploadClosingPackage";
 
 const JobDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
-  const { jobs, assignJob } = useJobs();
+  const { jobs, assignJob, updateStatus } = useJobs();
   const { items, updateUsed, addMaterial, fetchItems } = useJobMaterials(
     id || "",
   );
@@ -44,6 +45,12 @@ const JobDetailPage: React.FC = () => {
     setNewMaterial("");
     setNewQty(1);
     fetchItems();
+  };
+
+  const handleArchive = async () => {
+    if (!job?.id) return;
+    await updateStatus(job.id, "archived");
+    alert("Job archived.");
   };
 
   if (!job) return <p className="p-4">Job not found</p>;
@@ -132,6 +139,10 @@ const JobDetailPage: React.FC = () => {
           </tr>
         ))}
       </SZTable>
+      <UploadClosingPackage jobId={job.id} />
+      <SZButton onClick={handleArchive} disabled={job.status !== "complete"}>
+        Archive Job
+      </SZButton>
     </div>
   );
 };

--- a/installer-app/src/app/appointments/InstallerAppointmentPage.tsx
+++ b/installer-app/src/app/appointments/InstallerAppointmentPage.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { useAuth } from "../../lib/hooks/useAuth";
+import useInstallerAppointments from "../../lib/hooks/useInstallerAppointments";
+import JobStatusBadge from "../../components/JobStatusBadge";
+
+const InstallerAppointmentPage: React.FC = () => {
+  const { session } = useAuth();
+  const userId = session?.user?.id ?? null;
+  const { appointments, loading } = useInstallerAppointments(userId);
+
+  const today = new Date();
+  const isPast = (dateStr: string) => new Date(dateStr) < new Date(today.toDateString());
+
+  const upcoming = appointments.filter((a) => !isPast(a.start_time));
+  const past = appointments.filter((a) => isPast(a.start_time));
+
+  const formatDate = (dateStr: string) =>
+    new Date(dateStr).toLocaleDateString(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+    });
+
+  if (loading) return <p className="p-4">Loading...</p>;
+
+  return (
+    <div className="p-4 space-y-6">
+      <h1 className="text-2xl font-bold">Appointments</h1>
+
+      <section className="space-y-2">
+        <h2 className="text-xl font-semibold">Today & Upcoming</h2>
+        {upcoming.length === 0 ? (
+          <p>No upcoming appointments.</p>
+        ) : (
+          <ul className="space-y-2">
+            {upcoming.map((a) => (
+              <li
+                key={a.id}
+                className="p-2 border rounded flex justify-between items-center"
+              >
+                <Link to={`/installer/jobs/${a.id}`} className="flex flex-col">
+                  <span className="font-medium">{a.clinic_name}</span>
+                  <span className="text-sm text-gray-600">{formatDate(a.start_time)}</span>
+                </Link>
+                <JobStatusBadge status={a.status as any} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="text-xl font-semibold">Completed & Past</h2>
+        {past.length === 0 ? (
+          <p>No past jobs.</p>
+        ) : (
+          <ul className="space-y-2">
+            {past.map((a) => (
+              <li
+                key={a.id}
+                className="p-2 border rounded flex justify-between items-center"
+              >
+                <Link to={`/installer/jobs/${a.id}`} className="flex flex-col">
+                  <span className="font-medium">{a.clinic_name}</span>
+                  <span className="text-sm text-gray-600">{formatDate(a.start_time)}</span>
+                </Link>
+                <JobStatusBadge status={a.status as any} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default InstallerAppointmentPage;

--- a/installer-app/src/app/archived/ArchivedJobsPage.tsx
+++ b/installer-app/src/app/archived/ArchivedJobsPage.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from "react";
+import supabase from "../../lib/supabaseClient";
+import { SZInput } from "../../components/ui/SZInput";
+import { SZCard } from "../../components/ui/SZCard";
+
+interface Job {
+  id: string;
+  clinic_name: string;
+  completed_at: string;
+  contact_name: string;
+}
+
+export default function ArchivedJobsPage() {
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    const fetchArchivedJobs = async () => {
+      const { data, error } = await supabase
+        .from("jobs")
+        .select("id, clinic_name, contact_name, completed_at")
+        .eq("status", "archived")
+        .order("completed_at", { ascending: false });
+
+      if (!error) setJobs(data ?? []);
+    };
+
+    fetchArchivedJobs();
+  }, []);
+
+  const filtered = jobs.filter((j) =>
+    `${j.clinic_name} ${j.contact_name}`
+      .toLowerCase()
+      .includes(query.toLowerCase()),
+  );
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Archived Jobs</h1>
+      <SZInput
+        id="search"
+        label="Search"
+        placeholder="Search by clinic or contact"
+        value={query}
+        onChange={setQuery}
+      />
+      <div className="grid gap-3">
+        {filtered.map((job) => (
+          <SZCard key={job.id}>
+            <div className="space-y-1">
+              <h2 className="font-semibold">{job.clinic_name}</h2>
+              <p className="text-sm">Contact: {job.contact_name}</p>
+              <p className="text-xs text-gray-500">
+                Completed: {new Date(job.completed_at).toLocaleDateString()}
+              </p>
+            </div>
+          </SZCard>
+        ))}
+        {!filtered.length && (
+          <p className="italic text-sm">No matching jobs found.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/installer-app/src/app/install-manager/JobCloseoutPanel.tsx
+++ b/installer-app/src/app/install-manager/JobCloseoutPanel.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from "react";
+import uploadDocument from "../../lib/uploadDocument";
+import { SZModal } from "../../components/ui/SZModal";
+import { SZButton } from "../../components/ui/SZButton";
+import supabase from "../../lib/supabaseClient";
+
+interface JobCloseoutPanelProps {
+  jobId: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function JobCloseoutPanel({
+  jobId,
+  isOpen,
+  onClose,
+}: JobCloseoutPanelProps) {
+  const [permitFile, setPermitFile] = useState<File | null>(null);
+  const [inspectionFile, setInspectionFile] = useState<File | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const handleSubmit = async () => {
+    setSaving(true);
+
+    const uploads: Promise<any>[] = [];
+
+    if (permitFile) {
+      uploads.push(uploadDocument(permitFile, jobId, "permits"));
+    }
+
+    if (inspectionFile) {
+      uploads.push(uploadDocument(inspectionFile, jobId, "inspections"));
+    }
+
+    await Promise.all(uploads);
+
+    await supabase.from("jobs").update({ status: "archived" }).eq("id", jobId);
+
+    setSaving(false);
+    onClose();
+  };
+
+  return (
+    <SZModal isOpen={isOpen} onClose={onClose} title="Upload Closeout Documents">
+      <div className="space-y-4">
+        <label className="block">
+          Permit Document
+          <input
+            type="file"
+            accept="application/pdf"
+            onChange={(e) => setPermitFile(e.target.files?.[0] ?? null)}
+          />
+        </label>
+
+        <label className="block">
+          Inspection Photo
+          <input
+            type="file"
+            accept="image/*"
+            onChange={(e) => setInspectionFile(e.target.files?.[0] ?? null)}
+          />
+        </label>
+
+        <SZButton onClick={handleSubmit} isLoading={saving}>
+          Submit Closeout
+        </SZButton>
+      </div>
+    </SZModal>
+  );
+}

--- a/installer-app/src/app/install-manager/page.jsx
+++ b/installer-app/src/app/install-manager/page.jsx
@@ -10,6 +10,7 @@ import FeedbackReviewPanel from "./FeedbackReviewPanel";
 import { useNavigate } from "react-router-dom";
 import UploadDocsModal from "./UploadDocsModal";
 import AssignInventoryModal from "./AssignInventoryModal";
+import JobCloseoutPanel from "./JobCloseoutPanel";
 
 export default function InstallManagerDashboard() {
   const { jobs, loading, error, refresh } = useJobs();
@@ -18,6 +19,7 @@ export default function InstallManagerDashboard() {
   const [deleteJob, setDeleteJob] = useState(null);
   const [uploadJobId, setUploadJobId] = useState(null);
   const [inventoryJobId, setInventoryJobId] = useState(null);
+  const [closeoutJobId, setCloseoutJobId] = useState(null);
 
   const handleView = (id) => navigate(`/install-manager/job/${id}`);
   const handleEdit = (job) => setEditJob(job);
@@ -65,6 +67,15 @@ export default function InstallManagerDashboard() {
                   >
                     Assign Inventory
                   </SZButton>
+                  {job.status === "complete" && (
+                    <SZButton
+                      size="sm"
+                      variant="secondary"
+                      onClick={() => setCloseoutJobId(job.id)}
+                    >
+                      Closeout
+                    </SZButton>
+                  )}
                   <SZButton
                     size="sm"
                     variant="destructive"
@@ -113,6 +124,14 @@ export default function InstallManagerDashboard() {
         jobId={inventoryJobId}
         isOpen={!!inventoryJobId}
         onClose={() => setInventoryJobId(null)}
+      />
+      <JobCloseoutPanel
+        jobId={closeoutJobId}
+        isOpen={!!closeoutJobId}
+        onClose={() => {
+          setCloseoutJobId(null);
+          refresh();
+        }}
       />
       <h2 className="text-xl font-bold mt-8 mb-4">QA Review</h2>
       <QAReviewPanel />

--- a/installer-app/src/app/installer/jobs/InstallerJobPage.tsx
+++ b/installer-app/src/app/installer/jobs/InstallerJobPage.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { SZButton } from "../../../components/ui/SZButton";
+import { SZCard } from "../../../components/ui/SZCard";
+import useAuth from "../../../lib/hooks/useAuth";
+import useJobDetail from "../../../lib/hooks/useJobDetail";
+import MaterialsModal from "./MaterialsModal";
+import InstallerChecklistWizard from "../../../components/InstallerChecklistWizard";
+import DocumentViewerModal from "../../../installer/components/DocumentViewerModal";
+import supabase from "../../../lib/supabaseClient";
+
+const InstallerJobPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const { session } = useAuth();
+  const { job, loading, error, refresh } = useJobDetail(id || null);
+  const [docs, setDocs] = useState<any[]>([]);
+  const [showDocs, setShowDocs] = useState(false);
+  const [showChecklist, setShowChecklist] = useState(false);
+  const [showMaterials, setShowMaterials] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    async function loadDocs() {
+      const { data } = await supabase
+        .from("documents")
+        .select("id, name, type, path, url")
+        .eq("job_id", id);
+      setDocs(data ?? []);
+    }
+    loadDocs();
+  }, [id]);
+
+  if (loading) return <p className="p-4">Loading...</p>;
+  if (error) return <p className="p-4 text-red-500">{error}</p>;
+  if (!job) return <p className="p-4">Job not found</p>;
+  if (job.assigned_to !== session?.user?.id)
+    return <p className="p-4">Not authorized</p>;
+
+  const startJob = async () => {
+    if (!job) return;
+    await supabase.from("jobs").update({ status: "in_progress" }).eq("id", job.id);
+    refresh();
+  };
+
+  const checklistFinished = () => {
+    refresh();
+    setShowChecklist(false);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <SZCard
+        header={<h1 className="text-xl font-bold">{job.clinic_name}</h1>}
+        className="space-y-2"
+      >
+        <p>
+          <strong>Address:</strong> {job.address}
+        </p>
+        <p>
+          <strong>Status:</strong> {job.status}
+        </p>
+        {job.notes && (
+          <p className="whitespace-pre-line">
+            <strong>Notes:</strong> {job.notes}
+          </p>
+        )}
+      </SZCard>
+
+      <div className="flex flex-wrap gap-2">
+        <SZButton onClick={() => setShowDocs(true)} disabled={docs.length === 0}>
+          View Documents
+        </SZButton>
+        <SZButton onClick={() => setShowMaterials(true)}>Log Materials Used</SZButton>
+        <SZButton onClick={startJob} disabled={job.status !== "assigned"}>
+          Mark Job Started
+        </SZButton>
+        <SZButton onClick={() => setShowChecklist(true)} disabled={job.status !== "in_progress"}>
+          Mark Job Complete
+        </SZButton>
+      </div>
+
+      <MaterialsModal isOpen={showMaterials} onClose={() => setShowMaterials(false)} jobId={id || null} />
+      <InstallerChecklistWizard
+        isOpen={showChecklist}
+        onClose={() => {
+          setShowChecklist(false);
+          checklistFinished();
+        }}
+        job={job}
+      />
+      <DocumentViewerModal isOpen={showDocs} onClose={() => setShowDocs(false)} documents={docs} />
+    </div>
+  );
+};
+
+export default InstallerJobPage;

--- a/installer-app/src/app/installer/jobs/MaterialsModal.tsx
+++ b/installer-app/src/app/installer/jobs/MaterialsModal.tsx
@@ -1,0 +1,125 @@
+import React, { useState, useEffect } from "react";
+import { SZModal } from "../../../components/ui/SZModal";
+import { SZTable } from "../../../components/ui/SZTable";
+import { SZButton } from "../../../components/ui/SZButton";
+import { useJobMaterials } from "../../../lib/hooks/useJobMaterials";
+import useAuth from "../../../lib/hooks/useAuth";
+import uploadDocument from "../../../lib/uploadDocument";
+import supabase from "../../../lib/supabaseClient";
+
+export type MaterialsModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  jobId: string | null;
+};
+
+const MaterialsModal: React.FC<MaterialsModalProps> = ({
+  isOpen,
+  onClose,
+  jobId,
+}) => {
+  const { items, fetchItems } = useJobMaterials(jobId || "");
+  const { session } = useAuth();
+
+  const [quantities, setQuantities] = useState<Record<string, number>>({});
+  const [photos, setPhotos] = useState<Record<string, File | null>>({});
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const q: Record<string, number> = {};
+    items.forEach((it) => {
+      q[it.id] = 0;
+    });
+    setQuantities(q);
+    setPhotos({});
+  }, [isOpen, items]);
+
+  const updateQty = (id: string, qty: number) => {
+    setQuantities((q) => ({ ...q, [id]: qty }));
+  };
+
+  const updatePhoto = (id: string, file: File | null) => {
+    setPhotos((p) => ({ ...p, [id]: file }));
+  };
+
+  const canSubmit = Object.values(quantities).some((q) => q > 0);
+
+  const handleSubmit = async () => {
+    if (!jobId || !session?.user?.id || !canSubmit) return;
+    setSaving(true);
+    for (const item of items) {
+      const qty = quantities[item.id] || 0;
+      if (qty <= 0) continue;
+      let photoUrl: string | null = null;
+      const file = photos[item.id];
+      if (file) {
+        const uploaded = await uploadDocument(file);
+        photoUrl = uploaded?.url ?? null;
+      }
+      await supabase.from("job_materials_used").insert({
+        job_id: jobId,
+        material_id: item.material_id,
+        quantity: qty,
+        installer_id: session.user.id,
+        photo_url: photoUrl,
+      });
+      await supabase
+        .from("job_materials")
+        .update({ used_quantity: item.used_quantity + qty })
+        .eq("id", item.id);
+    }
+    await fetchItems();
+    setSaving(false);
+    onClose();
+  };
+
+  return (
+    <SZModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Log Materials Used"
+      footer={
+        <div className="flex justify-end gap-2">
+          <SZButton variant="secondary" onClick={onClose} disabled={saving}>
+            Cancel
+          </SZButton>
+          <SZButton onClick={handleSubmit} disabled={!canSubmit} isLoading={saving}>
+            Submit
+          </SZButton>
+        </div>
+      }
+    >
+      {items.length === 0 ? (
+        <p>No materials assigned.</p>
+      ) : (
+        <SZTable headers={["Material", "Qty", "Use", "Photo"]}>
+          {items.map((m) => (
+            <tr key={m.id} className="border-t">
+              <td className="p-2 border">{m.material_id}</td>
+              <td className="p-2 border text-right">{m.quantity}</td>
+              <td className="p-2 border">
+                <input
+                  type="number"
+                  min="0"
+                  className="border rounded px-2 py-1 w-20"
+                  value={quantities[m.id] ?? 0}
+                  onChange={(e) => updateQty(m.id, Number(e.target.value))}
+                />
+              </td>
+              <td className="p-2 border">
+                <input
+                  type="file"
+                  accept="image/*"
+                  onChange={(e) => updatePhoto(m.id, e.target.files?.[0] ?? null)}
+                />
+              </td>
+            </tr>
+          ))}
+        </SZTable>
+      )}
+    </SZModal>
+  );
+};
+
+export default MaterialsModal;

--- a/installer-app/src/app/installer/profile/InstallerProfilePage.tsx
+++ b/installer-app/src/app/installer/profile/InstallerProfilePage.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+import { SZInput } from '../../../components/ui/SZInput';
+import { SZButton } from '../../../components/ui/SZButton';
+import { useAuth } from '../../../lib/hooks/useAuth';
+import supabase from '../../../lib/supabaseClient';
+import uploadAvatar from '../../../lib/uploadAvatar';
+
+const InstallerProfilePage: React.FC = () => {
+  const { session } = useAuth();
+  const userId = session?.user?.id;
+  const email = session?.user?.email ?? '';
+  const [phone, setPhone] = useState('');
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!userId) return;
+    const load = async () => {
+      const { data } = await supabase
+        .from('profiles')
+        .select('phone, avatar_url')
+        .eq('user_id', userId)
+        .single();
+      if (data) {
+        setPhone(data.phone ?? '');
+        setAvatarUrl(data.avatar_url ?? null);
+      }
+      setLoading(false);
+    };
+    load();
+  }, [userId]);
+
+  const handleSave = async () => {
+    if (!userId) return;
+    setSaving(true);
+    let url = avatarUrl;
+    if (avatarFile) {
+      const uploaded = await uploadAvatar(userId, avatarFile);
+      if (uploaded) url = uploaded;
+    }
+    await supabase.from('profiles').upsert({
+      user_id: userId,
+      phone,
+      avatar_url: url,
+    });
+    setAvatarUrl(url);
+    setAvatarFile(null);
+    setSaving(false);
+  };
+
+  if (loading) return <p className="p-4">Loading...</p>;
+
+  return (
+    <div className="p-4 max-w-md space-y-4">
+      <h1 className="text-2xl font-bold">My Profile</h1>
+      <SZInput id="email" label="Email" value={email} onChange={() => {}} disabled />
+      <SZInput id="phone" label="Phone" value={phone} onChange={setPhone} />
+      <div className="space-y-1">
+        <label className="block text-sm font-medium text-gray-700">Avatar</label>
+        {avatarUrl && (
+          <img src={avatarUrl} alt="avatar" className="h-20 w-20 rounded-full object-cover" />
+        )}
+        <input type="file" accept="image/*" onChange={(e) => setAvatarFile(e.target.files?.[0] || null)} />
+      </div>
+      <SZButton onClick={handleSave} isLoading={saving}>Save</SZButton>
+    </div>
+  );
+};
+
+export default InstallerProfilePage;

--- a/installer-app/src/app/login/LoginPage.tsx
+++ b/installer-app/src/app/login/LoginPage.tsx
@@ -4,24 +4,19 @@ import { SZInput } from "../../components/ui/SZInput";
 import { SZButton } from "../../components/ui/SZButton";
 import { useAuth } from "../../lib/hooks/useAuth";
 
-const roleRoute: Record<string, string> = {
-  Installer: "/appointments",
-  Admin: "/admin/jobs/new",
-  Manager: "/manager/review",
-};
-
 const LoginPage: React.FC = () => {
-  const { signIn, role, loading } = useAuth();
+  const { signIn, role, session, loading } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [showToast, setShowToast] = useState(false);
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (role && roleRoute[role]) {
-      navigate(roleRoute[role], { replace: true });
+    if (session && role === "Installer") {
+      navigate("/installer", { replace: true });
     }
-  }, [role, navigate]);
+  }, [session, role, navigate]);
 
   const handleLogin = async () => {
     setError(null);
@@ -29,6 +24,8 @@ const LoginPage: React.FC = () => {
       await signIn(email, password);
     } catch (err: any) {
       setError(err.message);
+      setShowToast(true);
+      setTimeout(() => setShowToast(false), 3000);
     }
   };
 
@@ -43,7 +40,11 @@ const LoginPage: React.FC = () => {
         value={password}
         onChange={setPassword}
       />
-      {error && <p className="text-red-600 text-sm">{error}</p>}
+      {showToast && error && (
+        <div className="fixed top-4 right-4 bg-red-600 text-white px-4 py-2 rounded">
+          {error}
+        </div>
+      )}
       <SZButton onClick={handleLogin} isLoading={loading} fullWidth>
         Sign In
       </SZButton>

--- a/installer-app/src/app/manager/ManagerReview.tsx
+++ b/installer-app/src/app/manager/ManagerReview.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect } from "react";
+import { useJobs } from "../../lib/hooks/useJobs";
+import { SZButton } from "../../components/ui/SZButton";
+import JobAttachmentsPanel from "../../components/JobAttachmentsPanel";
+
+export default function ManagerReview() {
+  const { jobs, fetchJobs, updateStatus } = useJobs();
+
+  useEffect(() => {
+    fetchJobs();
+  }, [fetchJobs]);
+
+  const pending = jobs.filter((j) => j.status === "needs_qa");
+
+  const handleDecision = async (id: string, verdict: "complete" | "rework") => {
+    await updateStatus(id, verdict);
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto p-4 space-y-6">
+      <h1 className="text-2xl font-bold">QA Review</h1>
+      {pending.length === 0 ? (
+        <p>No jobs pending QA.</p>
+      ) : (
+        pending.map((job) => (
+          <div key={job.id} className="border p-4 rounded shadow space-y-4">
+            <div>
+              <div className="font-semibold">Clinic: {job.clinic_name}</div>
+              <div>Status: {job.status}</div>
+            </div>
+            <JobAttachmentsPanel jobId={job.id} />
+            <div className="mt-2 flex gap-3">
+              <SZButton onClick={() => handleDecision(job.id, "complete")}>Approve</SZButton>
+              <SZButton
+                variant="secondary"
+                onClick={() => handleDecision(job.id, "rework")}
+              >
+                Needs Rework
+              </SZButton>
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}

--- a/installer-app/src/app/manager/QAReviewPanel.tsx
+++ b/installer-app/src/app/manager/QAReviewPanel.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from "react";
+import { SZTable } from "../../components/ui/SZTable";
+import { SZButton } from "../../components/ui/SZButton";
+import useAuth from "../../lib/hooks/useAuth";
+import supabase from "../../lib/supabaseClient";
+
+interface QAJob {
+  id: string;
+  clinic_name: string;
+}
+
+const QAReviewPanel: React.FC = () => {
+  const { session } = useAuth();
+  const reviewerId = session?.user?.id;
+  const [jobs, setJobs] = useState<QAJob[]>([]);
+  const [notes, setNotes] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchJobs = async () => {
+    setLoading(true);
+    const { data, error } = await supabase
+      .from<QAJob>("jobs")
+      .select("id, clinic_name")
+      .eq("status", "needs_qa");
+    if (error) {
+      setError(error.message);
+      setJobs([]);
+    } else {
+      setError(null);
+      setJobs(data ?? []);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchJobs();
+  }, []);
+
+  const handleDecision = async (jobId: string, decision: "approved" | "rework") => {
+    if (!reviewerId) return;
+    const note = notes[jobId] ?? "";
+    await supabase.from("qa_reviews").insert({
+      job_id: jobId,
+      reviewer_id: reviewerId,
+      decision,
+      notes: note,
+    });
+    const newStatus = decision === "approved" ? "complete" : "rework";
+    await supabase.from("jobs").update({ status: newStatus }).eq("id", jobId);
+    fetchJobs();
+    setNotes((n) => ({ ...n, [jobId]: "" }));
+  };
+
+  if (loading) return <p className="p-4">Loading...</p>;
+  if (error) return <p className="p-4 text-red-500">{error}</p>;
+
+  return (
+    <div className="space-y-4">
+      {jobs.length === 0 ? (
+        <p>No jobs awaiting QA.</p>
+      ) : (
+        <SZTable headers={["Clinic", "Notes", "Actions"]}>
+          {jobs.map((job) => (
+            <tr key={job.id} className="border-t">
+              <td className="p-2 border">{job.clinic_name}</td>
+              <td className="p-2 border">
+                <input
+                  type="text"
+                  value={notes[job.id] ?? ""}
+                  onChange={(e) =>
+                    setNotes((n) => ({ ...n, [job.id]: e.target.value }))
+                  }
+                  className="border rounded w-full p-1"
+                />
+              </td>
+              <td className="p-2 border space-x-2">
+                <SZButton size="sm" onClick={() => handleDecision(job.id, "approved")}>Approve</SZButton>
+                <SZButton
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => handleDecision(job.id, "rework")}
+                >
+                  Rework
+                </SZButton>
+              </td>
+            </tr>
+          ))}
+        </SZTable>
+      )}
+    </div>
+  );
+};
+
+export default QAReviewPanel;

--- a/installer-app/src/components/InstallerChecklistWizard.tsx
+++ b/installer-app/src/components/InstallerChecklistWizard.tsx
@@ -1,0 +1,219 @@
+import React, { useState } from "react";
+import { SZModal } from "./ui/SZModal";
+import { SZButton } from "./ui/SZButton";
+import uploadDocument from "../lib/uploadDocument";
+import supabase from "../lib/supabaseClient";
+import { useJobs } from "../lib/hooks/useJobs";
+import useAuth from "../lib/hooks/useAuth";
+
+export interface ChecklistWizardProps {
+  isOpen: boolean;
+  onClose: () => void;
+  job: {
+    id: string;
+    assigned_to: string | null;
+    status: string;
+  } | null;
+}
+
+const InstallerChecklistWizard: React.FC<ChecklistWizardProps> = ({
+  isOpen,
+  onClose,
+  job,
+}) => {
+  const { session } = useAuth();
+  const { updateStatus } = useJobs();
+
+  const [step, setStep] = useState(0);
+  const [customerPresent, setCustomerPresent] = useState<string>("");
+  const [absenceReason, setAbsenceReason] = useState<string>("");
+  const [materialsUsed, setMaterialsUsed] = useState<string>("");
+  const [systemVerified, setSystemVerified] = useState<boolean>(false);
+  const [photoFile, setPhotoFile] = useState<File | null>(null);
+  const [notes, setNotes] = useState<string>("");
+  const [saving, setSaving] = useState(false);
+
+  const allowed =
+    job &&
+    job.status === "in_progress" &&
+    job.assigned_to === session?.user?.id;
+
+  if (!isOpen || !allowed || !job) return null;
+
+  const stepValid = () => {
+    switch (step) {
+      case 0:
+        return (
+          customerPresent === "yes" ||
+          (customerPresent === "no" && absenceReason.trim() !== "")
+        );
+      case 1:
+        return materialsUsed.trim() !== "";
+      case 2:
+        return systemVerified;
+      case 3:
+        return !!photoFile;
+      case 4:
+        return notes.trim() !== "";
+      default:
+        return false;
+    }
+  };
+
+  const next = () => {
+    if (stepValid()) setStep((s) => s + 1);
+  };
+
+  const back = () => setStep((s) => Math.max(0, s - 1));
+
+  const handleSubmit = async () => {
+    if (!stepValid() || !job) return;
+    setSaving(true);
+    let photoUrl: string | null = null;
+    if (photoFile) {
+      const uploaded = await uploadDocument(photoFile);
+      photoUrl = uploaded?.url ?? null;
+    }
+    await supabase.from("checklists").insert({
+      job_id: job.id,
+      completed: true,
+      responses: {
+        customerPresent,
+        absenceReason,
+        materialsUsed,
+        systemVerified,
+        photoUrl,
+        notes,
+      },
+    });
+    await updateStatus(job.id, "needs_qa");
+    setSaving(false);
+    onClose();
+  };
+
+  return (
+    <SZModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Installer Close-Out Checklist"
+    >
+      {step === 0 && (
+        <div className="space-y-4">
+          <p>Was the customer present?</p>
+          <div className="flex gap-4">
+            <label className="inline-flex items-center gap-1">
+              <input
+                type="radio"
+                value="yes"
+                checked={customerPresent === "yes"}
+                onChange={() => setCustomerPresent("yes")}
+              />
+              Yes
+            </label>
+            <label className="inline-flex items-center gap-1">
+              <input
+                type="radio"
+                value="no"
+                checked={customerPresent === "no"}
+                onChange={() => setCustomerPresent("no")}
+              />
+              No
+            </label>
+          </div>
+          {customerPresent === "no" && (
+            <div>
+              <label htmlFor="absence_reason" className="block text-sm font-semibold">
+                Reason for absence
+              </label>
+              <input
+                id="absence_reason"
+                type="text"
+                className="border rounded w-full p-2"
+                value={absenceReason}
+                onChange={(e) => setAbsenceReason(e.target.value)}
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      {step === 1 && (
+        <div>
+          <label htmlFor="materials" className="block text-sm font-semibold mb-1">
+            Materials Used
+          </label>
+          <textarea
+            id="materials"
+            rows={4}
+            className="border rounded w-full p-2"
+            value={materialsUsed}
+            onChange={(e) => setMaterialsUsed(e.target.value)}
+          />
+        </div>
+      )}
+
+      {step === 2 && (
+        <div className="space-y-2">
+          <label className="inline-flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={systemVerified}
+              onChange={(e) => setSystemVerified(e.target.checked)}
+            />
+            System verification complete
+          </label>
+        </div>
+      )}
+
+      {step === 3 && (
+        <div>
+          <label className="block text-sm font-semibold mb-1" htmlFor="photo">
+            Upload Photo
+          </label>
+          <input
+            id="photo"
+            type="file"
+            accept="image/*"
+            onChange={(e) => setPhotoFile(e.target.files?.[0] ?? null)}
+          />
+        </div>
+      )}
+
+      {step === 4 && (
+        <div>
+          <label htmlFor="notes" className="block text-sm font-semibold mb-1">
+            Additional Notes
+          </label>
+          <textarea
+            id="notes"
+            rows={4}
+            className="border rounded w-full p-2"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+          />
+        </div>
+      )}
+
+      <div className="mt-6 flex justify-between">
+        {step > 0 ? (
+          <SZButton variant="secondary" size="sm" onClick={back}>
+            Back
+          </SZButton>
+        ) : (
+          <span />
+        )}
+        {step < 4 ? (
+          <SZButton size="sm" onClick={next} disabled={!stepValid()}>
+            Next
+          </SZButton>
+        ) : (
+          <SZButton onClick={handleSubmit} disabled={!stepValid() || saving} isLoading={saving}>
+            Submit Checklist
+          </SZButton>
+        )}
+      </div>
+    </SZModal>
+  );
+};
+
+export default InstallerChecklistWizard;

--- a/installer-app/src/components/JobAttachmentsPanel.tsx
+++ b/installer-app/src/components/JobAttachmentsPanel.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from "react";
+import supabase from "../lib/supabaseClient";
+
+interface Attachment {
+  name: string;
+  url: string;
+}
+
+interface JobAttachmentsPanelProps {
+  jobId: string;
+}
+
+export default function JobAttachmentsPanel({ jobId }: JobAttachmentsPanelProps) {
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+
+  useEffect(() => {
+    const fetchAttachments = async () => {
+      const { data, error } = await supabase.storage
+        .from("documents")
+        .list(jobId, { limit: 100 });
+
+      if (error) {
+        console.error(error);
+        return;
+      }
+
+      const urls = await Promise.all(
+        (data ?? []).map(async (file) => {
+          const { data: signed } = await supabase.storage
+            .from("documents")
+            .createSignedUrl(`${jobId}/${file.name}`, 3600);
+          return { name: file.name, url: signed?.signedUrl || "#" };
+        })
+      );
+
+      setAttachments(urls);
+    };
+
+    fetchAttachments();
+  }, [jobId]);
+
+  if (!attachments.length) return <p className="text-sm italic">No documents uploaded.</p>;
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-lg font-semibold">Job Attachments</h2>
+      <ul className="space-y-1">
+        {attachments.map((file) => (
+          <li key={file.name}>
+            <a
+              href={file.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 underline text-sm"
+            >
+              {file.name}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/installer-app/src/components/JobStatusBadge.tsx
+++ b/installer-app/src/components/JobStatusBadge.tsx
@@ -7,6 +7,7 @@ export type JobStatus =
   | "needs_qa"
   | "complete"
   | "rework"
+  | "archived"
   | "unassigned";
 
 const statusMap: Record<
@@ -18,6 +19,7 @@ const statusMap: Record<
   needs_qa: { label: "Needs QA", variant: "orange" },
   complete: { label: "Complete", variant: "green" },
   rework: { label: "Rework", variant: "red" },
+  archived: { label: "Archived", variant: "gray" },
   unassigned: { label: "Unassigned", variant: "gray" },
 };
 

--- a/installer-app/src/components/UploadClosingPackage.tsx
+++ b/installer-app/src/components/UploadClosingPackage.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from "react";
+import supabase from "../lib/supabaseClient";
+import { SZButton } from "./ui/SZButton";
+
+interface Props {
+  jobId: string;
+  onComplete?: () => void;
+}
+
+export default function UploadClosingPackage({ jobId, onComplete }: Props) {
+  const [files, setFiles] = useState<FileList | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleUpload = async () => {
+    if (!files) return;
+    setUploading(true);
+    setError(null);
+
+    try {
+      for (let i = 0; i < files.length; i++) {
+        const file = files[i];
+        const path = `${jobId}/closing-${file.name}`;
+        const { error: uploadErr } = await supabase.storage
+          .from("documents")
+          .upload(path, file, { upsert: true });
+        if (uploadErr) throw uploadErr;
+      }
+      if (onComplete) onComplete();
+    } catch (err: any) {
+      console.error(err);
+      setError("Upload failed.");
+    }
+
+    setUploading(false);
+  };
+
+  return (
+    <div className="space-y-3">
+      <label className="block text-sm font-medium">Upload Closing Documents</label>
+      <input
+        type="file"
+        accept=".pdf,.jpg,.png"
+        multiple
+        onChange={(e) => setFiles(e.target.files)}
+      />
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <SZButton onClick={handleUpload} disabled={!files} isLoading={uploading}>
+        Upload Files
+      </SZButton>
+    </div>
+  );
+}

--- a/installer-app/src/lib/authHelpers.ts
+++ b/installer-app/src/lib/authHelpers.ts
@@ -1,0 +1,9 @@
+export async function getUserRole(userId: string): Promise<string | null> {
+  const { default: supabase } = await import('./supabaseClient');
+  const { data } = await supabase
+    .from('user_roles')
+    .select('role')
+    .eq('user_id', userId)
+    .single();
+  return data?.role ?? null;
+}

--- a/installer-app/src/lib/hooks/useActivityLog.ts
+++ b/installer-app/src/lib/hooks/useActivityLog.ts
@@ -1,0 +1,61 @@
+import { useState, useEffect, useCallback } from "react";
+import supabase from "../supabaseClient";
+
+export interface ActivityJob {
+  id: string;
+  clinic_name: string;
+  status: string;
+  created_at: string;
+  completed_at: string | null;
+}
+
+export function useActivityLog(
+  userId: string | null,
+  startDate?: string,
+  endDate?: string,
+) {
+  const [jobs, setJobs] = useState<ActivityJob[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchLog = useCallback(async () => {
+    if (!userId) {
+      setJobs([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    let query = supabase
+      .from("jobs")
+      .select("id, clinic_name, status, created_at, checklists(created_at)")
+      .eq("assigned_to", userId)
+      .order("created_at", { ascending: false });
+    if (startDate) query = query.gte("created_at", startDate);
+    if (endDate) query = query.lte("created_at", endDate);
+    const { data, error } = await query;
+    if (error) {
+      setError(error.message);
+      setJobs([]);
+    } else {
+      setError(null);
+      const processed =
+        data?.map((j: any) => ({
+          id: j.id,
+          clinic_name: j.clinic_name,
+          status: j.status,
+          created_at: j.created_at,
+          completed_at: j.checklists?.[0]?.created_at ?? null,
+        })) ?? [];
+      setJobs(processed);
+    }
+    setLoading(false);
+  }, [userId, startDate, endDate]);
+
+  useEffect(() => {
+    fetchLog();
+  }, [fetchLog]);
+
+  return { jobs, loading, error, fetchLog } as const;
+}
+
+export default useActivityLog;

--- a/installer-app/src/lib/hooks/useAuth.tsx
+++ b/installer-app/src/lib/hooks/useAuth.tsx
@@ -1,8 +1,10 @@
 import { createContext, useState, useEffect, useContext, ReactNode } from "react";
 import supabase from "../supabaseClient";
+import { getUserRole } from "../authHelpers";
 
 type AuthContextType = {
   session: any;
+  user: any;
   role: string | null;
   loading: boolean;
   signIn: (email: string, password: string) => Promise<void>;
@@ -13,16 +15,25 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [session, setSession] = useState<any>(null);
+  const [user, setUser] = useState<any>(null);
   const [role, setRole] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const init = async () => {
-      const { data: { session } } = await supabase.auth.getSession();
-      setSession(session);
-      if (session?.user) {
-        const { data } = await supabase.from("user_roles").select("role").eq("user_id", session.user.id).single();
-        setRole(data?.role || null);
+      const { data: { session: active } } = await supabase.auth.getSession();
+      let current = active;
+      if (!current) {
+        const stored = localStorage.getItem("sb_session");
+        if (stored) current = JSON.parse(stored);
+      }
+      setSession(current);
+      setUser(current?.user ?? null);
+      if (current?.user) {
+        const role = await getUserRole(current.user.id);
+        setRole(role);
+      } else {
+        setRole(null);
       }
       setLoading(false);
     };
@@ -33,22 +44,22 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const { data, error } = await supabase.auth.signInWithPassword({ email, password });
     if (error) throw error;
     setSession(data.session);
-    const { data: roleData } = await supabase
-      .from("user_roles")
-      .select("role")
-      .eq("user_id", data.user.id)
-      .single();
-    setRole(roleData?.role || null);
+    setUser(data.user);
+    localStorage.setItem("sb_session", JSON.stringify(data.session));
+    const role = await getUserRole(data.user.id);
+    setRole(role);
   };
 
   const signOut = async () => {
     await supabase.auth.signOut();
     setSession(null);
+    setUser(null);
     setRole(null);
+    localStorage.removeItem("sb_session");
   };
 
   return (
-    <AuthContext.Provider value={{ session, role, loading, signIn, signOut }}>
+    <AuthContext.Provider value={{ session, user, role, loading, signIn, signOut }}>
       {children}
     </AuthContext.Provider>
   );

--- a/installer-app/src/lib/hooks/useInstallerAppointments.ts
+++ b/installer-app/src/lib/hooks/useInstallerAppointments.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect, useCallback } from "react";
+import supabase from "../supabaseClient";
+
+export interface Appointment {
+  id: string;
+  clinic_name: string;
+  start_time: string;
+  status: string;
+}
+
+export default function useInstallerAppointments(userId: string | null) {
+  const [appointments, setAppointments] = useState<Appointment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAppointments = useCallback(async () => {
+    if (!userId) {
+      setAppointments([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const { data, error } = await supabase
+      .from("jobs")
+      .select("id, clinic_name, status, scheduled_date")
+      .eq("assigned_to", userId)
+      .order("scheduled_date", { ascending: true });
+    if (error) {
+      setError(error.message);
+      setAppointments([]);
+    } else {
+      setError(null);
+      setAppointments(
+        (data ?? []).map((j: any) => ({
+          id: j.id,
+          clinic_name: j.clinic_name,
+          start_time: j.scheduled_date,
+          status: j.status,
+        }))
+      );
+    }
+    setLoading(false);
+  }, [userId]);
+
+  useEffect(() => {
+    fetchAppointments();
+  }, [fetchAppointments]);
+
+  return { appointments, loading, error, refresh: fetchAppointments } as const;
+}

--- a/installer-app/src/lib/hooks/useJobDetail.ts
+++ b/installer-app/src/lib/hooks/useJobDetail.ts
@@ -1,0 +1,45 @@
+import { useState, useEffect, useCallback } from "react";
+import supabase from "../supabaseClient";
+
+export interface JobDetail {
+  id: string;
+  clinic_name: string;
+  address: string;
+  notes: string | null;
+  status: string;
+  assigned_to: string | null;
+}
+
+export default function useJobDetail(jobId: string | null) {
+  const [job, setJob] = useState<JobDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchJob = useCallback(async () => {
+    if (!jobId) {
+      setJob(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const { data, error } = await supabase
+      .from("jobs")
+      .select("id, clinic_name, address, notes, status, assigned_to")
+      .eq("id", jobId)
+      .single();
+    if (error) {
+      setError(error.message);
+      setJob(null);
+    } else {
+      setError(null);
+      setJob(data as JobDetail);
+    }
+    setLoading(false);
+  }, [jobId]);
+
+  useEffect(() => {
+    fetchJob();
+  }, [fetchJob]);
+
+  return { job, loading, error, refresh: fetchJob } as const;
+}

--- a/installer-app/src/lib/hooks/useJobs.ts
+++ b/installer-app/src/lib/hooks/useJobs.ts
@@ -79,17 +79,10 @@ export function useJobs() {
     return data;
   }, []);
 
-  const updateStatus = useCallback(async (id: string, status: string) => {
-    const { data, error } = await supabase
-      .from<Job>("jobs")
-      .update({ status })
-      .eq("id", id)
-      .select()
-      .single();
-    if (error) throw error;
-    setJobs((js) => js.map((j) => (j.id === id ? data : j)));
-    return data;
-  }, []);
+  const updateStatus = async (jobId: string, newStatus: string) => {
+    await supabase.from("jobs").update({ status: newStatus }).eq("id", jobId);
+    await fetchJobs();
+  };
 
   useEffect(() => {
     fetchJobs();

--- a/installer-app/src/lib/hooks/useMaterials.ts
+++ b/installer-app/src/lib/hooks/useMaterials.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect, useCallback } from "react";
+import supabase from "../supabaseClient";
+
+export interface Material {
+  id: string;
+  name: string;
+}
+
+export default function useMaterials() {
+  const [materials, setMaterials] = useState<Material[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchMaterials = useCallback(async () => {
+    setLoading(true);
+    const { data, error } = await supabase
+      .from<Material>("materials")
+      .select("id, name")
+      .order("name", { ascending: true });
+    if (error) {
+      setError(error.message);
+      setMaterials([]);
+    } else {
+      setError(null);
+      setMaterials(data ?? []);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    fetchMaterials();
+  }, [fetchMaterials]);
+
+  return { materials, loading, error, refresh: fetchMaterials } as const;
+}

--- a/installer-app/src/lib/uploadAvatar.ts
+++ b/installer-app/src/lib/uploadAvatar.ts
@@ -1,0 +1,15 @@
+export default async function uploadAvatar(userId: string, file: File): Promise<string | null> {
+  try {
+    const { default: supabase } = await import('./supabaseClient');
+    const filePath = `${userId}.jpg`;
+    const { error } = await supabase.storage
+      .from('avatars')
+      .upload(filePath, file, { upsert: true, contentType: file.type });
+    if (error) throw error;
+    const { data } = supabase.storage.from('avatars').getPublicUrl(filePath);
+    return data.publicUrl ?? null;
+  } catch (err) {
+    console.error('Failed to upload avatar', err);
+    return null;
+  }
+}

--- a/installer-app/src/lib/uploadDocument.js
+++ b/installer-app/src/lib/uploadDocument.js
@@ -1,4 +1,4 @@
-export default async function uploadDocument(file) {
+export default async function uploadDocument(file, jobId, folder) {
   if (!file) return null;
 
   if (process.env.NODE_ENV === "test") {
@@ -14,7 +14,11 @@ export default async function uploadDocument(file) {
   try {
     const { default: supabase } = await import("./supabaseClient");
     const ext = file.name.split(".").pop();
-    const filePath = `${Date.now()}_${file.name}`;
+    const filePathParts = [];
+    if (jobId) filePathParts.push(jobId);
+    if (folder) filePathParts.push(folder);
+    filePathParts.push(`${Date.now()}_${file.name}`);
+    const filePath = filePathParts.join("/");
 
     const { error } = await supabase.storage
       .from("documents")


### PR DESCRIPTION
## Summary
- create archived jobs viewer with search
- remove old manager page and use new viewer in `/archived`
- update routes to expose archived page for managers and admins

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68574cd411ac832dbaf9b316de335e4e