### PR TITLE
Add ERP & FSM components

### DIFF
--- a/installer-app/src/app/admin/AdminDashboard.jsx
+++ b/installer-app/src/app/admin/AdminDashboard.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import useAuth from '../../lib/hooks/useAuth';
+import useKPIs from '../../lib/hooks/useKPIs';
+
+export default function AdminDashboard() {
+  const { role } = useAuth();
+  const kpis = useKPIs();
+
+  if (role !== 'Admin') return <div className="p-4">Access denied</div>;
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Business KPIs</h1>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="p-4 bg-white rounded shadow">
+          <h3 className="text-sm font-medium">Open Jobs</h3>
+          <p className="text-xl font-semibold">{kpis.jobs['in_progress'] || 0}</p>
+        </div>
+        <div className="p-4 bg-white rounded shadow">
+          <h3 className="text-sm font-medium">Invoices</h3>
+          <p className="text-xl font-semibold">{kpis.invoices}</p>
+        </div>
+        <div className="p-4 bg-white rounded shadow">
+          <h3 className="text-sm font-medium">Revenue</h3>
+          <p className="text-xl font-semibold">${kpis.revenue.toFixed(2)}</p>
+        </div>
+        <div className="p-4 bg-white rounded shadow">
+          <h3 className="text-sm font-medium">Leads</h3>
+          <p className="text-xl font-semibold">{kpis.leads}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/installer-app/src/app/admin/TechnicianPayReport.jsx
+++ b/installer-app/src/app/admin/TechnicianPayReport.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import useAuth from '../../lib/hooks/useAuth';
+import usePayReport from '../../lib/hooks/usePayReport';
+import { SZInput } from '../../components/ui/SZInput';
+import { SZTable } from '../../components/ui/SZTable';
+
+export default function TechnicianPayReport() {
+  const { role } = useAuth();
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+  const rows = usePayReport(start, end);
+
+  if (!['Admin', 'Manager'].includes(role ?? '')) return <div className="p-4">Access denied</div>;
+
+  const total = rows.reduce((s, r) => s + r.payout, 0);
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Technician Pay Report</h1>
+      <div className="flex gap-2 flex-wrap">
+        <SZInput id="start" label="Start" type="date" value={start} onChange={setStart} />
+        <SZInput id="end" label="End" type="date" value={end} onChange={setEnd} />
+      </div>
+      <SZTable headers={["Job", "Installer", "Payout", "Completed"]}>
+        {rows.map(r => (
+          <tr key={r.job_id} className="border-t">
+            <td className="p-2 border">{r.job_id}</td>
+            <td className="p-2 border">{r.installer}</td>
+            <td className="p-2 border">${r.payout.toFixed(2)}</td>
+            <td className="p-2 border">{r.completed_at ? new Date(r.completed_at).toLocaleDateString() : ''}</td>
+          </tr>
+        ))}
+      </SZTable>
+      <div className="font-semibold">Total: ${total.toFixed(2)}</div>
+    </div>
+  );
+}

--- a/installer-app/src/app/clients/ClientProfilePage.jsx
+++ b/installer-app/src/app/clients/ClientProfilePage.jsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import useAuth from '../../lib/hooks/useAuth';
+import useClinics from '../../lib/hooks/useClinics';
+import useQuotes from '../../lib/hooks/useQuotes';
+import { useJobs } from '../../lib/hooks/useJobs';
+import useInvoices from '../../lib/hooks/useInvoices';
+import usePayments from '../../lib/hooks/usePayments';
+import { SZTable } from '../../components/ui/SZTable';
+
+export default function ClientProfilePage() {
+  const { role } = useAuth();
+  const { id } = useParams();
+  const [clients] = useClinics();
+  const [quotes] = useQuotes();
+  const { jobs } = useJobs();
+  const [invoices] = useInvoices();
+  const [payments] = usePayments();
+  const client = clients.find(c => c.id === id);
+
+  if (!role) return null;
+  if (!client) return <div className="p-4">Client not found</div>;
+
+  const clientQuotes = quotes.filter(q => q.client_id === id);
+  const clientJobs = jobs.filter(j => j.client_id === id);
+  const clientInvoices = invoices.filter(i => i.client_id === id);
+  const clientPayments = payments.filter(p => clientInvoices.some(i => i.id === p.invoice_id));
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">{client.name}</h1>
+      <div>
+        <p>Contact: {client.contact_name}</p>
+        <p>Email: {client.contact_email}</p>
+        <p>Address: {client.address}</p>
+      </div>
+      <section>
+        <h2 className="font-semibold">Quotes</h2>
+        <SZTable headers={["Title", "Status", "Total"]}>
+          {clientQuotes.map(q => (
+            <tr key={q.id} className="border-t">
+              <td className="p-2 border">{q.title}</td>
+              <td className="p-2 border">{q.status}</td>
+              <td className="p-2 border">${(q.total ?? 0).toFixed(2)}</td>
+            </tr>
+          ))}
+        </SZTable>
+      </section>
+      <section>
+        <h2 className="font-semibold">Jobs</h2>
+        <SZTable headers={["Clinic", "Status"]}>
+          {clientJobs.map(j => (
+            <tr key={j.id} className="border-t">
+              <td className="p-2 border">{j.clinic_name}</td>
+              <td className="p-2 border">{j.status}</td>
+            </tr>
+          ))}
+        </SZTable>
+      </section>
+      <section>
+        <h2 className="font-semibold">Invoices</h2>
+        <SZTable headers={["Amount", "Status"]}>
+          {clientInvoices.map(i => (
+            <tr key={i.id} className="border-t">
+              <td className="p-2 border">${i.amount.toFixed(2)}</td>
+              <td className="p-2 border">{i.status}</td>
+            </tr>
+          ))}
+        </SZTable>
+      </section>
+      <section>
+        <h2 className="font-semibold">Payments</h2>
+        <SZTable headers={["Amount", "Method", "Date"]}>
+          {clientPayments.map(p => (
+            <tr key={p.id} className="border-t">
+              <td className="p-2 border">${p.amount.toFixed(2)}</td>
+              <td className="p-2 border">{p.method}</td>
+              <td className="p-2 border">{new Date(p.received_at).toLocaleDateString()}</td>
+            </tr>
+          ))}
+        </SZTable>
+      </section>
+    </div>
+  );
+}

--- a/installer-app/src/app/install-manager/InvoiceBuilderPage.jsx
+++ b/installer-app/src/app/install-manager/InvoiceBuilderPage.jsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import useAuth from '../../lib/hooks/useAuth';
+import useInvoices from '../../lib/hooks/useInvoices';
+import { useJobs } from '../../lib/hooks/useJobs';
+import useQuotes from '../../lib/hooks/useQuotes';
+import { SZInput } from '../../components/ui/SZInput';
+import { SZButton } from '../../components/ui/SZButton';
+
+export default function InvoiceBuilderPage() {
+  const { role } = useAuth();
+  const { createInvoice } = useInvoices()[1];
+  const { jobs } = useJobs();
+  const [quotes] = useQuotes();
+  const [params] = useSearchParams();
+  const jobId = params.get('job_id');
+
+  const [clientId, setClientId] = useState('');
+  const [amount, setAmount] = useState('0');
+
+  useEffect(() => {
+    if (jobId) {
+      const j = jobs.find(j => j.id === jobId);
+      if (j && j.quote_id) {
+        const q = quotes.find(x => x.id === j.quote_id);
+        if (q) {
+          setClientId(q.client_id || '');
+          setAmount(String(q.total || 0));
+        }
+      }
+    }
+  }, [jobId, jobs, quotes]);
+
+  if (role !== 'InstallManager' && role !== 'Admin') return <div className="p-4">Access denied</div>;
+
+  const save = async () => {
+    await createInvoice({ job_id: jobId, client_id: clientId, amount: Number(amount), issued_at: new Date().toISOString(), status: 'draft' });
+    alert('Invoice saved');
+  };
+
+  return (
+    <div className="p-4 space-y-4 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold">Invoice Builder</h1>
+      <SZInput id="client" label="Client ID" value={clientId} onChange={setClientId} />
+      <SZInput id="amount" label="Amount" type="number" value={amount} onChange={setAmount} />
+      <SZButton onClick={save}>Save Invoice</SZButton>
+    </div>
+  );
+}

--- a/installer-app/src/app/installer/jobs/InstallerJobFlow.jsx
+++ b/installer-app/src/app/installer/jobs/InstallerJobFlow.jsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import useAuth from '../../../lib/hooks/useAuth';
+import { useJobs } from '../../../lib/hooks/useJobs';
+import { useChecklist } from '../../../lib/hooks/useChecklist';
+import { SZButton } from '../../../components/ui/SZButton';
+import uploadDocument from '../../../lib/uploadDocument';
+import supabase from '../../../lib/supabaseClient';
+
+export default function InstallerJobFlow() {
+  const { session, role } = useAuth();
+  const { jobs } = useJobs();
+  const [activeId, setActiveId] = useState(null);
+  const myJobs = jobs.filter(j => j.assigned_to === session?.user?.id);
+  const activeJob = myJobs.find(j => j.id === activeId) || null;
+  const checklist = useChecklist(activeId || '');
+  const [feedback, setFeedback] = useState('');
+
+  if (role !== 'Installer') {
+    return <div className="p-4">Not authorized</div>;
+  }
+
+  const toggle = async (id, completed) => {
+    await checklist.toggleItem(id, completed);
+  };
+
+  const upload = async e => {
+    const file = e.target.files?.[0];
+    if (!file || !activeId) return;
+    const doc = await uploadDocument(file);
+    if (!doc) return;
+    await supabase.from('documents').insert({
+      job_id: activeId,
+      name: doc.name,
+      url: doc.url,
+    });
+    e.target.value = '';
+  };
+
+  const submitFeedback = async () => {
+    if (!feedback.trim() || !activeId) return;
+    await supabase.from('feedback').insert({ job_id: activeId, notes: feedback });
+    setFeedback('');
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      {!activeJob && (
+        <div>
+          <h1 className="text-xl font-bold mb-2">My Jobs</h1>
+          <ul className="space-y-2">
+            {myJobs.map(j => (
+              <li key={j.id} className="border p-2 rounded" onClick={() => setActiveId(j.id)}>
+                {j.clinic_name}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {activeJob && (
+        <div className="space-y-4">
+          <SZButton size="sm" variant="secondary" onClick={() => setActiveId(null)}>
+            Back
+          </SZButton>
+          <h2 className="text-xl font-semibold">{activeJob.clinic_name}</h2>
+          <div>
+            <h3 className="font-medium mb-2">Checklist</h3>
+            {checklist.items.map(item => (
+              <label key={item.id} className="flex items-center gap-2 mb-1">
+                <input
+                  type="checkbox"
+                  checked={item.completed}
+                  onChange={e => toggle(item.id, e.target.checked)}
+                />
+                {item.description}
+              </label>
+            ))}
+          </div>
+          <div>
+            <input type="file" onChange={upload} />
+          </div>
+          <div className="space-y-2">
+            <textarea
+              className="border rounded w-full p-2"
+              placeholder="Leave feedback"
+              value={feedback}
+              onChange={e => setFeedback(e.target.value)}
+            />
+            <SZButton onClick={submitFeedback}>Submit Feedback</SZButton>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/installer-app/src/app/sales/CRMPipelineView.jsx
+++ b/installer-app/src/app/sales/CRMPipelineView.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import useAuth from '../../lib/hooks/useAuth';
+import useLeads from '../../lib/hooks/useLeads';
+import supabase from '../../lib/supabaseClient';
+
+const stages = ['new', 'appointment_scheduled', 'proposal_sent', 'won', 'lost'];
+
+export default function CRMPipelineView() {
+  const { role, user } = useAuth();
+  const { leads, fetchLeads } = useLeads();
+
+  if (!['Sales', 'Manager'].includes(role ?? '')) return <div className="p-4">Access denied</div>;
+
+  const onDrop = async (e, status) => {
+    const id = e.dataTransfer.getData('text');
+    await supabase.from('leads').update({ status }).eq('id', id);
+    fetchLeads();
+  };
+
+  return (
+    <div className="flex overflow-x-auto gap-4 p-4">
+      {stages.map(stage => (
+        <div
+          key={stage}
+          onDragOver={e => e.preventDefault()}
+          onDrop={e => onDrop(e, stage)}
+          className="min-w-[200px] flex-1 bg-gray-50 border rounded p-2"
+        >
+          <h3 className="font-semibold capitalize mb-2">{stage.replace('_', ' ')}</h3>
+          {leads.filter(l => l.status === stage && (role !== 'Sales' || l.sales_rep_id === user?.id)).map(l => (
+            <div
+              key={l.id}
+              draggable
+              onDragStart={e => e.dataTransfer.setData('text', l.id)}
+              className="p-2 mb-2 bg-white border rounded shadow-sm text-sm"
+            >
+              {l.clinic_name}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/installer-app/src/app/sales/LeadIntakeForm.jsx
+++ b/installer-app/src/app/sales/LeadIntakeForm.jsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import useAuth from '../../lib/hooks/useAuth';
+import useLeads from '../../lib/hooks/useLeads';
+import { SZInput } from '../../components/ui/SZInput';
+import { SZButton } from '../../components/ui/SZButton';
+
+export default function LeadIntakeForm() {
+  const { role } = useAuth();
+  const { createLead } = useLeads();
+  const [lead, setLead] = useState({ clinic_name: '', contact_name: '', contact_phone: '', contact_email: '', address: '' });
+  if (role !== 'Sales' && role !== 'Admin') return <div className="p-4">Access denied</div>;
+
+  const handleChange = (k, v) => setLead(l => ({ ...l, [k]: v }));
+  const submit = async () => {
+    if (!lead.clinic_name) return;
+    await createLead({ ...lead, sales_rep_id: null });
+    setLead({ clinic_name: '', contact_name: '', contact_phone: '', contact_email: '', address: '' });
+    alert('Lead added');
+  };
+
+  return (
+    <div className="p-4 space-y-2 max-w-lg mx-auto">
+      <h1 className="text-2xl font-bold">New Lead</h1>
+      <SZInput id="clinic" label="Clinic Name" value={lead.clinic_name} onChange={v => handleChange('clinic_name', v)} />
+      <SZInput id="contact" label="Contact Name" value={lead.contact_name} onChange={v => handleChange('contact_name', v)} />
+      <SZInput id="phone" label="Phone" value={lead.contact_phone} onChange={v => handleChange('contact_phone', v)} />
+      <SZInput id="email" label="Email" value={lead.contact_email} onChange={v => handleChange('contact_email', v)} />
+      <SZInput id="address" label="Address" value={lead.address} onChange={v => handleChange('address', v)} />
+      <SZButton onClick={submit}>Create Lead</SZButton>
+    </div>
+  );
+}

--- a/installer-app/src/app/sales/QuoteBuilderPage.jsx
+++ b/installer-app/src/app/sales/QuoteBuilderPage.jsx
@@ -1,0 +1,73 @@
+import React, { useState, useEffect } from 'react';
+import useAuth from '../../lib/hooks/useAuth';
+import useClinics from '../../lib/hooks/useClinics';
+import supabase from '../../lib/supabaseClient';
+import { SZInput } from '../../components/ui/SZInput';
+import { SZButton } from '../../components/ui/SZButton';
+
+export default function QuoteBuilderPage() {
+  const { role, user } = useAuth();
+  const [clients] = useClinics();
+  const [clientId, setClientId] = useState('');
+  const [items, setItems] = useState([{ description: '', quantity: 1, unit_price: 0 }]);
+  const [tax, setTax] = useState(0);
+
+  useEffect(() => {
+    if (clients.length && !clientId) setClientId(clients[0].id);
+  }, [clients, clientId]);
+
+  if (role !== 'Sales' && role !== 'Admin') return <div className="p-4">Access denied</div>;
+
+  const updateItem = (idx, key, value) => {
+    setItems(list => list.map((it, i) => (i === idx ? { ...it, [key]: value } : it)));
+  };
+
+  const addItem = () => setItems(i => [...i, { description: '', quantity: 1, unit_price: 0 }]);
+  const removeItem = idx => setItems(i => i.filter((_, n) => n !== idx));
+
+  const total = items.reduce((s, it) => s + it.quantity * it.unit_price, 0);
+  const totalWithTax = total + total * (tax / 100);
+
+  const saveQuote = async (send = false) => {
+    const { data: quote } = await supabase
+      .from('quotes')
+      .insert({ client_id: clientId, status: send ? 'sent' : 'draft', created_by: user?.id })
+      .select()
+      .single();
+    if (!quote) return;
+    const rows = items.map(i => ({ ...i, quote_id: quote.id, total: i.quantity * i.unit_price }));
+    if (rows.length) await supabase.from('quote_items').insert(rows);
+    alert(`Quote ${send ? 'sent' : 'saved'}!`);
+  };
+
+  return (
+    <div className="p-6 space-y-4 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold">Create Quote</h1>
+      <div>
+        <label className="block text-sm font-medium" htmlFor="client">Client</label>
+        <select id="client" className="border p-2 rounded w-full" value={clientId} onChange={e => setClientId(e.target.value)}>
+          {clients.map(c => (
+            <option key={c.id} value={c.id}>{c.name}</option>
+          ))}
+        </select>
+      </div>
+      {items.map((it, idx) => (
+        <div key={idx} className="grid grid-cols-3 gap-2 items-end">
+          <SZInput id={`desc_${idx}`} label="Description" value={it.description} onChange={v => updateItem(idx, 'description', v)} />
+          <SZInput id={`qty_${idx}`} label="Qty" type="number" value={String(it.quantity)} onChange={v => updateItem(idx, 'quantity', parseInt(v))} />
+          <SZInput id={`price_${idx}`} label="Unit Price" type="number" value={String(it.unit_price)} onChange={v => updateItem(idx, 'unit_price', parseFloat(v))} />
+          <SZButton size="sm" variant="destructive" onClick={() => removeItem(idx)}>Remove</SZButton>
+        </div>
+      ))}
+      <SZButton size="sm" variant="secondary" onClick={addItem}>Add Line</SZButton>
+      <div>
+        <SZInput id="tax" label="Tax %" type="number" value={String(tax)} onChange={setTax} />
+      </div>
+      <div className="font-semibold">Total: ${totalWithTax.toFixed(2)}</div>
+      <div className="flex gap-2">
+        <SZButton onClick={() => saveQuote(false)}>Save Draft</SZButton>
+        <SZButton onClick={() => saveQuote(true)}>Send Quote</SZButton>
+      </div>
+    </div>
+  );
+}

--- a/installer-app/src/app/sales/QuoteListPage.jsx
+++ b/installer-app/src/app/sales/QuoteListPage.jsx
@@ -1,0 +1,54 @@
+import React, { useState, useMemo } from 'react';
+import useAuth from '../../lib/hooks/useAuth';
+import useQuotes from '../../lib/hooks/useQuotes';
+import { SZTable } from '../../components/ui/SZTable';
+import { SZInput } from '../../components/ui/SZInput';
+
+export default function QuoteListPage() {
+  const { role, user } = useAuth();
+  const [quotes] = useQuotes();
+  const [status, setStatus] = useState('all');
+  const [search, setSearch] = useState('');
+
+  if (!['Sales', 'Manager', 'Admin'].includes(role ?? '')) {
+    return <div className="p-4">Access denied</div>;
+  }
+
+  const filtered = useMemo(() => {
+    let list = quotes;
+    if (role === 'Sales') list = list.filter(q => q.created_by === user?.id);
+    if (status !== 'all') list = list.filter(q => q.status === status);
+    if (search.trim()) {
+      const term = search.toLowerCase();
+      list = list.filter(q => (q.client_name ?? '').toLowerCase().includes(term));
+    }
+    return list;
+  }, [quotes, status, search, role, user]);
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Quotes</h1>
+      <div className="flex gap-2 flex-wrap items-end">
+        <SZInput id="search" placeholder="Search" value={search} onChange={setSearch} />
+        <select className="border rounded px-2 py-1" value={status} onChange={e => setStatus(e.target.value)}>
+          <option value="all">All</option>
+          <option value="draft">Draft</option>
+          <option value="sent">Sent</option>
+          <option value="approved">Approved</option>
+          <option value="rejected">Rejected</option>
+        </select>
+      </div>
+      <div className="overflow-x-auto">
+        <SZTable headers={["Client", "Total", "Status"]}>
+          {filtered.map(q => (
+            <tr key={q.id} className="border-t">
+              <td className="p-2 border">{q.client_name}</td>
+              <td className="p-2 border">${(q.total ?? 0).toFixed(2)}</td>
+              <td className="p-2 border">{q.status}</td>
+            </tr>
+          ))}
+        </SZTable>
+      </div>
+    </div>
+  );
+}

--- a/installer-app/src/components/ConvertQuoteToJobButton.jsx
+++ b/installer-app/src/components/ConvertQuoteToJobButton.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import useAuth from '../lib/hooks/useAuth';
+import { useJobs } from '../lib/hooks/useJobs';
+import useQuotes from '../lib/hooks/useQuotes';
+import { SZButton } from './ui/SZButton';
+
+export default function ConvertQuoteToJobButton({ quote }) {
+  const { role } = useAuth();
+  const { createJob } = useJobs();
+  const [, { updateQuote }] = useQuotes();
+
+  if ((quote?.status !== 'approved') || !['Sales', 'Admin'].includes(role ?? '')) {
+    return null;
+  }
+
+  const convert = async () => {
+    await createJob({
+      client_id: quote.client_id,
+      quote_id: quote.id,
+      clinic_name: quote.client_name || '',
+      contact_name: '',
+      contact_phone: '',
+      address: '',
+      status: 'Scheduled',
+    });
+    await updateQuote(quote.id, { client_id: quote.client_id, status: 'converted', items: [] });
+    alert('Quote converted to job');
+  };
+
+  return (
+    <SZButton size="sm" onClick={convert}>Convert to Job</SZButton>
+  );
+}

--- a/installer-app/src/components/MaterialUsageLogger.jsx
+++ b/installer-app/src/components/MaterialUsageLogger.jsx
@@ -1,0 +1,84 @@
+import React, { useState, useEffect } from 'react';
+import { SZModal } from './ui/SZModal';
+import { SZButton } from './ui/SZButton';
+import supabase from '../lib/supabaseClient';
+import useAuth from '../lib/hooks/useAuth';
+
+export default function MaterialUsageLogger({ jobId, open, onClose }) {
+  const { session, role } = useAuth();
+  const [materials, setMaterials] = useState([]);
+  const [rows, setRows] = useState({});
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!open || !jobId) return;
+    supabase
+      .from('job_materials')
+      .select('id, material_id, quantity, used_quantity')
+      .eq('job_id', jobId)
+      .then(({ data }) => {
+        setMaterials(data || []);
+        const q = {};
+        (data || []).forEach(m => { q[m.id] = 0; });
+        setRows(q);
+      });
+  }, [open, jobId]);
+
+  if (role !== 'Installer') return null;
+  const updateQty = (id, qty) => setRows(r => ({ ...r, [id]: qty }));
+
+  const submit = async () => {
+    setSaving(true);
+    for (const id of Object.keys(rows)) {
+      const qty = rows[id];
+      if (qty > 0) {
+        const jm = materials.find(m => m.id === id);
+        await supabase.from('job_materials_used').insert({
+          job_id: jobId,
+          product_service_id: jm.material_id,
+          quantity: qty,
+          cost_snapshot: 0,
+          user_id: session?.user?.id,
+        });
+        await supabase.from('job_materials').update({ used_quantity: jm.used_quantity + qty }).eq('id', id);
+      }
+    }
+    setSaving(false);
+    onClose();
+  };
+
+  const canSubmit = Object.values(rows).some(q => q > 0);
+
+  return (
+    <SZModal isOpen={open} onClose={onClose} title="Log Materials Used" footer={null}>
+      {materials.length === 0 ? (
+        <p>No materials assigned.</p>
+      ) : (
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="bg-gray-50">
+              <th className="p-2 border">Material</th>
+              <th className="p-2 border">Qty</th>
+              <th className="p-2 border">Use</th>
+            </tr>
+          </thead>
+          <tbody>
+            {materials.map(m => (
+              <tr key={m.id} className="border-t">
+                <td className="p-2 border">{m.material_id}</td>
+                <td className="p-2 border text-right">{m.quantity}</td>
+                <td className="p-2 border">
+                  <input type="number" className="border rounded px-2 py-1 w-20" value={rows[m.id] || 0} onChange={e => updateQty(m.id, Number(e.target.value))} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      <div className="mt-4 flex justify-end gap-2">
+        <SZButton variant="secondary" onClick={onClose}>Cancel</SZButton>
+        <SZButton onClick={submit} disabled={!canSubmit} isLoading={saving}>Save</SZButton>
+      </div>
+    </SZModal>
+  );
+}

--- a/installer-app/src/components/PaymentLoggingModal.jsx
+++ b/installer-app/src/components/PaymentLoggingModal.jsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import ModalWrapper from '../installer/components/ModalWrapper';
+import { SZButton } from './ui/SZButton';
+import { SZInput } from './ui/SZInput';
+import usePayments from '../lib/hooks/usePayments';
+import useAuth from '../lib/hooks/useAuth';
+
+export default function PaymentLoggingModal({ invoiceId, open, onClose }) {
+  const { role } = useAuth();
+  const [, { createPayment }] = usePayments();
+  const [amount, setAmount] = useState('');
+  const [method, setMethod] = useState('cash');
+
+  if (role !== 'Admin') return null;
+  const save = async () => {
+    await createPayment({ invoice_id: invoiceId, amount: Number(amount), method });
+    onClose();
+  };
+
+  return (
+    <ModalWrapper isOpen={open} onClose={onClose}>
+      <h2 className="text-lg font-semibold mb-2">Log Payment</h2>
+      <SZInput id="amt" label="Amount" type="number" value={amount} onChange={setAmount} />
+      <div className="my-2">
+        <label className="block text-sm font-medium" htmlFor="method">Method</label>
+        <select id="method" className="border rounded px-2 py-1 w-full" value={method} onChange={e => setMethod(e.target.value)}>
+          <option value="cash">Cash</option>
+          <option value="credit">Credit</option>
+          <option value="check">Check</option>
+        </select>
+      </div>
+      <div className="flex justify-end gap-2 mt-4">
+        <SZButton variant="secondary" onClick={onClose}>Cancel</SZButton>
+        <SZButton onClick={save}>Save</SZButton>
+      </div>
+    </ModalWrapper>
+  );
+}

--- a/installer-app/src/lib/hooks/useKPIs.ts
+++ b/installer-app/src/lib/hooks/useKPIs.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import supabase from '../supabaseClient';
+
+export default function useKPIs() {
+  const [data, setData] = useState({ jobs: {}, invoices: 0, revenue: 0, leads: 0 });
+
+  useEffect(() => {
+    async function load() {
+      const { data: jobs } = await supabase.from('jobs').select('status');
+      const { data: invoices } = await supabase.from('invoices').select('amount');
+      const { data: payments } = await supabase.from('payments').select('amount');
+      const { data: leads } = await supabase.from('leads').select('id');
+
+      const jobCounts = {} as Record<string, number>;
+      (jobs ?? []).forEach(j => { jobCounts[j.status] = (jobCounts[j.status] || 0) + 1; });
+      const invoiceTotal = (invoices ?? []).length;
+      const revenue = (payments ?? []).reduce((s,p)=>s+p.amount,0);
+      setData({ jobs: jobCounts, invoices: invoiceTotal, revenue, leads: (leads ?? []).length });
+    }
+    load();
+  }, []);
+
+  return data;
+}

--- a/installer-app/src/lib/hooks/usePayReport.ts
+++ b/installer-app/src/lib/hooks/usePayReport.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import supabase from '../supabaseClient';
+
+export interface PayRow {
+  job_id: string;
+  installer: string | null;
+  payout: number;
+  completed_at: string;
+}
+
+export default function usePayReport(start?: string, end?: string, installerId?: string) {
+  const [rows, setRows] = useState<PayRow[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      let query = supabase
+        .from('jobs')
+        .select('id, assigned_to, completed_at, job_materials(quantity, unit_labor_cost)')
+        .eq('status', 'complete');
+      if (start) query = query.gte('completed_at', start);
+      if (end) query = query.lte('completed_at', end);
+      if (installerId) query = query.eq('assigned_to', installerId);
+      const { data } = await query;
+      const mapped = (data ?? []).map(j => {
+        const payout = (j.job_materials ?? []).reduce((s,m)=>s + m.quantity * m.unit_labor_cost,0);
+        return { job_id: j.id, installer: j.assigned_to, payout, completed_at: j.completed_at } as PayRow;
+      });
+      setRows(mapped);
+    }
+    load();
+  }, [start, end, installerId]);
+
+  return rows;
+}


### PR DESCRIPTION
## Summary
- implement InstallerJobFlow for installers to complete checklists and feedback
- add Quote Builder and Quote List pages for Sales
- allow converting an approved quote to a job
- add Invoice Builder page for managers
- include modal for logging payments
- client profile page shows quote/job/invoice/payment history
- lead intake form and CRM pipeline board
- admin dashboard with basic KPIs
- technician pay report page
- material usage logger modal
- add KPI and pay report hooks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857d0602b38832d854c97014ea0cbcd