### PR TITLE
Implement global layout and remove clinic_name

### DIFF
--- a/installer-app/src/App.jsx
+++ b/installer-app/src/App.jsx
@@ -23,8 +23,9 @@ import InventoryPage from "./app/installer/InventoryPage";
 import JobHistoryPage from "./app/installer/JobHistoryPage";
 import LoginPage from "./app/login/LoginPage";
 import { AuthProvider } from "./lib/hooks/useAuth";
-import { RequireRole as RequireRoleOutlet } from "./components/auth/RequireAuth";
+import RequireAuth, { RequireRole as RequireRoleOutlet } from "./components/auth/RequireAuth";
 import RequireRole from "./components/RequireRole";
+import AppLayout from "./components/layout/AppLayout";
 import UnderConstructionPage from "./app/UnderConstructionPage";
 
 const ClientsPage = lazy(() => import("./app/clients/ClientsPage"));
@@ -42,161 +43,166 @@ const App = () => {
     <Router>
       <AuthProvider>
         <Suspense fallback={<div>Loading...</div>}>
-        <Routes>
-          <Route path="/login" element={<LoginPage />} />
+          <Routes>
+            <Route path="/login" element={<LoginPage />} />
+            <Route element={<RequireAuth />}>
+              <Route element={<AppLayout />}>
+                <Route element={<RequireRoleOutlet role="Installer" />}>
+                  <Route path="/" element={<InstallerHomePage />} />
+                  <Route path="/appointments" element={<InstallerAppointmentPage />} />
+                  <Route path="/activity" element={<ActivityLogPage />} />
+                  <Route path="/ifi" element={<IFIDashboard />} />
+                  <Route path="/job/:jobId" element={<JobDetailPage />} />
+                  <Route path="/mock-jobs" element={<MockJobsPage />} />
+                  <Route path="/installer" element={<InstallerDashboard />} />
+                  <Route path="/installer/dashboard" element={<InstallerDashboard />} />
+                  <Route path="/installer/jobs/:id" element={<InstallerJobPage />} />
+                  <Route path="/installer/profile" element={<InstallerProfilePage />} />
+                  <Route path="/installer/inventory" element={<InventoryPage />} />
+                  <Route path="/installer/history" element={<JobHistoryPage />} />
+                  <Route path="/feedback" element={<FeedbackPage />} />
+                </Route>
 
-          <Route element={<RequireRoleOutlet role="Installer" />}>
-            <Route path="/" element={<InstallerHomePage />} />
-            <Route path="/appointments" element={<InstallerAppointmentPage />} />
-            <Route path="/activity" element={<ActivityLogPage />} />
-            <Route path="/ifi" element={<IFIDashboard />} />
-            <Route path="/job/:jobId" element={<JobDetailPage />} />
-            <Route path="/mock-jobs" element={<MockJobsPage />} />
-            <Route path="/installer" element={<InstallerDashboard />} />
-            <Route path="/installer/dashboard" element={<InstallerDashboard />} />
-            <Route path="/installer/jobs/:id" element={<InstallerJobPage />} />
-            <Route path="/installer/profile" element={<InstallerProfilePage />} />
-            <Route path="/installer/inventory" element={<InventoryPage />} />
-            <Route path="/installer/history" element={<JobHistoryPage />} />
-            <Route path="/feedback" element={<FeedbackPage />} />
-          </Route>
+                <Route element={<RequireRoleOutlet role="Admin" />}>
+                  <Route path="/admin/dashboard" element={<AdminDashboard />} />
+                  <Route path="/admin/jobs/new" element={<AdminNewJob />} />
+                  <Route path="/admin/jobs/:id" element={<AdminJobDetail />} />
+                </Route>
 
-          <Route element={<RequireRoleOutlet role="Admin" />}>
-            <Route path="/admin/dashboard" element={<AdminDashboard />} />
-            <Route path="/admin/jobs/new" element={<AdminNewJob />} />
-            <Route path="/admin/jobs/:id" element={<AdminJobDetail />} />
-          </Route>
+                <Route element={<RequireRoleOutlet role="Manager" />}>
+                  <Route path="/manager/qa" element={<QAReviewPanel />} />
+                  <Route path="/manager/review" element={<ManagerReview />} />
+                </Route>
 
-          <Route element={<RequireRoleOutlet role="Manager" />}>
-            <Route path="/manager/qa" element={<QAReviewPanel />} />
-            <Route path="/manager/review" element={<ManagerReview />} />
-          </Route>
+                <Route
+                  path="/manager/archived"
+                  element={
+                    <RequireRole role={["Manager", "Admin"]}>
+                      <ArchivedJobsPage />
+                    </RequireRole>
+                  }
+                />
+                <Route
+                  path="/archived"
+                  element={
+                    <RequireRole role={["Manager", "Admin"]}>
+                      <ArchivedJobsPage />
+                    </RequireRole>
+                  }
+                />
 
-          <Route
-            path="/manager/archived"
-            element={
-              <RequireRole role={["Manager", "Admin"]}>
-                <ArchivedJobsPage />
-              </RequireRole>
-            }
-          />
-          <Route
-            path="/archived"
-            element={
-              <RequireRole role={["Manager", "Admin"]}>
-                <ArchivedJobsPage />
-              </RequireRole>
-            }
-          />
+                <Route
+                  path="/install-manager"
+                  element={
+                    <RequireRole role={["Manager", "Admin"]}>
+                      <InstallManagerDashboard />
+                    </RequireRole>
+                  }
+                />
+                <Route
+                  path="/install-manager/dashboard"
+                  element={
+                    <RequireRole role={["Manager", "Admin"]}>
+                      <InstallManagerDashboard />
+                    </RequireRole>
+                  }
+                />
+                <Route
+                  path="/install-manager/job/new"
+                  element={
+                    <RequireRole role={["Manager", "Admin"]}>
+                      <NewJobBuilderPage />
+                    </RequireRole>
+                  }
+                />
+                <Route
+                  path="/install-manager/job/:id"
+                  element={
+                    <RequireRole role={["Manager", "Admin"]}>
+                      <UnderConstructionPage />
+                    </RequireRole>
+                  }
+                />
 
-          <Route
-            path="/install-manager"
-            element={
-              <RequireRole role={["Manager", "Admin"]}>
-                <InstallManagerDashboard />
-              </RequireRole>
-            }
-          />
-          <Route
-            path="/install-manager/dashboard"
-            element={
-              <RequireRole role={["Manager", "Admin"]}>
-                <InstallManagerDashboard />
-              </RequireRole>
-            }
-          />
-          <Route
-            path="/install-manager/job/new"
-            element={
-              <RequireRole role={["Manager", "Admin"]}>
-                <NewJobBuilderPage />
-              </RequireRole>
-            }
-          />
-          <Route
-            path="/install-manager/job/:id"
-            element={
-              <RequireRole role={["Manager", "Admin"]}>
-                <UnderConstructionPage />
-              </RequireRole>
-            }
-          />
+                <Route
+                  path="/clients"
+                  element={
+                    <RequireRole role={["Manager", "Admin"]}>
+                      <ClientsPage />
+                    </RequireRole>
+                  }
+                />
+                <Route
+                  path="/crm/leads"
+                  element={
+                    <RequireRole role={["Sales", "Manager", "Admin"]}>
+                      <LeadsPage />
+                    </RequireRole>
+                  }
+                />
+                <Route
+                  path="/sales/dashboard"
+                  element={
+                    <RequireRole role={["Sales", "Manager", "Admin"]}>
+                      <SalesDashboard />
+                    </RequireRole>
+                  }
+                />
+                <Route
+                  path="/quotes"
+                  element={
+                    <RequireRole role={["Manager", "Admin"]}>
+                      <QuotesPage />
+                    </RequireRole>
+                  }
+                />
+                <Route
+                  path="/invoices"
+                  element={
+                    <RequireRole role={["Manager", "Admin"]}>
+                      <InvoicesPage />
+                    </RequireRole>
+                  }
+                />
+                <Route
+                  path="/payments"
+                  element={
+                    <RequireRole role={["Manager", "Admin"]}>
+                      <PaymentsPage />
+                    </RequireRole>
+                  }
+                />
+                <Route
+                  path="/messages"
+                  element={
+                    <RequireRole role={["Manager", "Admin"]}>
+                      <MessagesPanel />
+                    </RequireRole>
+                  }
+                />
+                <Route
+                  path="/time-tracking"
+                  element={
+                    <RequireRole role={["Manager", "Admin"]}>
+                      <TimeTrackingPanel />
+                    </RequireRole>
+                  }
+                />
+                <Route
+                  path="/reports"
+                  element={
+                    <RequireRole role={["Manager", "Admin"]}>
+                      <ReportsPage />
+                    </RequireRole>
+                  }
+                />
 
-          <Route
-            path="/clients"
-            element={
-              <RequireRole role={["Manager", "Admin"]}>
-                <ClientsPage />
-              </RequireRole>
-            }
-          />
-          <Route
-            path="/crm/leads"
-            element={
-              <RequireRole role={["Sales", "Manager", "Admin"]}>
-                <LeadsPage />
-              </RequireRole>
-            }
-          />
-          <Route
-            path="/sales/dashboard"
-            element={
-              <RequireRole role={["Sales", "Manager", "Admin"]}>
-                <SalesDashboard />
-              </RequireRole>
-            }
-          />
-          <Route
-            path="/quotes"
-            element={
-              <RequireRole role={["Manager", "Admin"]}>
-                <QuotesPage />
-              </RequireRole>
-            }
-          />
-          <Route
-            path="/invoices"
-            element={
-              <RequireRole role={["Manager", "Admin"]}>
-                <InvoicesPage />
-              </RequireRole>
-            }
-          />
-          <Route
-            path="/payments"
-            element={
-              <RequireRole role={["Manager", "Admin"]}>
-                <PaymentsPage />
-              </RequireRole>
-            }
-          />
-          <Route
-            path="/messages"
-            element={
-              <RequireRole role={["Manager", "Admin"]}>
-                <MessagesPanel />
-              </RequireRole>
-            }
-          />
-          <Route
-            path="/time-tracking"
-            element={
-              <RequireRole role={["Manager", "Admin"]}>
-                <TimeTrackingPanel />
-              </RequireRole>
-            }
-          />
-          <Route
-            path="/reports"
-            element={
-              <RequireRole role={["Manager", "Admin"]}>
-                <ReportsPage />
-              </RequireRole>
-            }
-          />
-          <Route path="*" element={<Navigate to="/login" replace />} />
-        </Routes>
-      </Suspense>
+                <Route path="*" element={<Navigate to="/" replace />} />
+              </Route>
+            </Route>
+            <Route path="*" element={<Navigate to="/login" replace />} />
+          </Routes>
+        </Suspense>
       </AuthProvider>
     </Router>
   );

--- a/installer-app/src/app/activity/ActivityLogPage.tsx
+++ b/installer-app/src/app/activity/ActivityLogPage.tsx
@@ -59,7 +59,7 @@ const ActivityLogPage: React.FC = () => {
           {jobs.map((j) => (
             <tr key={j.id} className="border-t">
               <td className="p-2 border">{j.id}</td>
-              <td className="p-2 border">{j.clinic_name}</td>
+              <td className="p-2 border">{j.client_name}</td>
               <td className="p-2 border">
                 {j.completed_at ? formatDate(j.completed_at) : "-"}
               </td>

--- a/installer-app/src/app/install-manager/job/NewJobBuilderPage.tsx
+++ b/installer-app/src/app/install-manager/job/NewJobBuilderPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { SZInput } from "../../../components/ui/SZInput";
 import { SZButton } from "../../../components/ui/SZButton";
 import supabase from "../../../lib/supabaseClient";
+import useClients from "../../../lib/hooks/useClients";
 
 interface Material {
   id: string;
@@ -20,7 +21,7 @@ interface MaterialRow {
 }
 
 const initialJob = {
-  clinic_name: "",
+  client_id: "",
   contact_name: "",
   contact_phone: "",
   contact_email: "",
@@ -30,6 +31,7 @@ const initialJob = {
 
 const NewJobBuilderPage: React.FC = () => {
   const navigate = useNavigate();
+  const [clients] = useClients();
   const [job, setJob] = useState(initialJob);
   const [materials, setMaterials] = useState<Material[]>([]);
   const [rows, setRows] = useState<MaterialRow[]>([
@@ -90,7 +92,7 @@ const NewJobBuilderPage: React.FC = () => {
   }, 0);
 
   const handleSubmit = async () => {
-    if (!job.clinic_name || !job.contact_name || !job.address) return;
+    if (!job.client_id || !job.contact_name || !job.address) return;
     setSubmitting(true);
     const { data, error } = await supabase.from("jobs").insert(job).select();
     if (error || !data) {
@@ -125,7 +127,24 @@ const NewJobBuilderPage: React.FC = () => {
       <section className="space-y-4">
         <h2 className="text-xl font-semibold">Job Info</h2>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <SZInput id="clinic_name" label="Clinic Name" value={job.clinic_name} onChange={(v) => handleJobChange("clinic_name", v)} />
+          <div>
+            <label className="block text-sm font-medium text-gray-700" htmlFor="client">
+              Client
+            </label>
+            <select
+              id="client"
+              className="block w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-500"
+              value={job.client_id}
+              onChange={(e) => handleJobChange("client_id", e.target.value)}
+            >
+              <option value="">Select</option>
+              {clients.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </div>
           <SZInput id="contact_name" label="Contact Name" value={job.contact_name} onChange={(v) => handleJobChange("contact_name", v)} />
           <SZInput id="contact_phone" label="Contact Phone" value={job.contact_phone} onChange={(v) => handleJobChange("contact_phone", v)} />
           <SZInput id="contact_email" label="Contact Email" value={job.contact_email} onChange={(v) => handleJobChange("contact_email", v)} />

--- a/installer-app/src/app/installer/InstallerDashboard.tsx
+++ b/installer-app/src/app/installer/InstallerDashboard.tsx
@@ -25,7 +25,7 @@ const InstallerDashboard: React.FC = () => {
               to={`/installer/jobs/${j.id}`}
               className="text-blue-600 underline"
             >
-              {j.clinic_name}
+              {j.client_name}
             </Link>
           </li>
         ))}

--- a/installer-app/src/app/installer/JobHistoryPage.tsx
+++ b/installer-app/src/app/installer/JobHistoryPage.tsx
@@ -6,7 +6,7 @@ import { Link } from "react-router-dom";
 
 interface JobRow {
   id: string;
-  clinic_name: string;
+  client_name: string | null;
   completed_at: string;
   status: string;
 }
@@ -19,11 +19,19 @@ export default function JobHistoryPage() {
     const fetch = async () => {
       const { data, error } = await supabase
         .from("jobs")
-        .select("id, clinic_name, completed_at, status")
+        .select("id, client_id, completed_at, status, clients(name)")
         .eq("assigned_to", session?.user?.id)
         .in("status", ["needs_qa", "complete", "rework"])
         .order("completed_at", { ascending: false });
-      if (!error) setJobs(data ?? []);
+      if (!error) {
+        const list = (data ?? []).map((j: any) => ({
+          id: j.id,
+          client_name: j.clients?.name ?? null,
+          completed_at: j.completed_at,
+          status: j.status,
+        }));
+        setJobs(list);
+      }
     };
     if (session?.user?.id) fetch();
   }, [session]);
@@ -46,7 +54,7 @@ export default function JobHistoryPage() {
         {jobs.map((job) => (
           <SZCard key={job.id} className="p-3 flex justify-between items-center">
             <div>
-              <div className="font-semibold">{job.clinic_name}</div>
+              <div className="font-semibold">{job.client_name}</div>
               <div className="text-sm text-gray-500">
                 {new Date(job.completed_at).toLocaleDateString()}
               </div>

--- a/installer-app/src/components/ConvertQuoteToJobButton.jsx
+++ b/installer-app/src/components/ConvertQuoteToJobButton.jsx
@@ -17,7 +17,6 @@ export default function ConvertQuoteToJobButton({ quote }) {
     await createJob({
       client_id: quote.client_id,
       quote_id: quote.id,
-      clinic_name: quote.client_name || '',
       contact_name: '',
       contact_phone: '',
       address: '',

--- a/installer-app/src/components/layout/AppLayout.tsx
+++ b/installer-app/src/components/layout/AppLayout.tsx
@@ -1,0 +1,30 @@
+import { useState } from "react";
+import { Outlet } from "react-router-dom";
+import Header from "./Header";
+import Sidebar from "./Sidebar";
+import Breadcrumbs from "./Breadcrumbs";
+
+export const AppLayout: React.FC = () => {
+  const [sidebarOpen, setSidebarOpen] = useState(() => {
+    const stored = localStorage.getItem("sidebarOpen");
+    return stored ? stored === "true" : true;
+  });
+
+  const toggle = () => setSidebarOpen((o) => !o);
+  const close = () => setSidebarOpen(false);
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header onToggleSidebar={toggle} />
+      <div className="flex flex-1">
+        <Sidebar open={sidebarOpen} onClose={close} />
+        <main className="flex-1 p-4 overflow-y-auto md:ml-64">
+          <Breadcrumbs />
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default AppLayout;

--- a/installer-app/src/components/layout/Breadcrumbs.tsx
+++ b/installer-app/src/components/layout/Breadcrumbs.tsx
@@ -1,0 +1,42 @@
+import { Link, useLocation } from "react-router-dom";
+
+interface BreadcrumbsProps {
+  names?: Record<string, string>;
+}
+
+export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ names = {} }) => {
+  const location = useLocation();
+  const segments = location.pathname.split("/").filter(Boolean);
+
+  if (segments.length === 0) return null;
+
+  const crumbs = segments.map((seg, idx) => {
+    const path = "/" + segments.slice(0, idx + 1).join("/");
+    const label = names[seg] || seg.replace(/-/g, " ");
+    return { path, label };
+  });
+
+  return (
+    <nav className="text-sm mb-4" aria-label="Breadcrumb">
+      <ol className="list-none p-0 inline-flex">
+        <li>
+          <Link to="/">Home</Link>
+        </li>
+        {crumbs.map((crumb, idx) => (
+          <li key={crumb.path} className="flex items-center">
+            <span className="mx-2">/</span>
+            {idx === crumbs.length - 1 ? (
+              <span className="text-gray-500">{crumb.label}</span>
+            ) : (
+              <Link to={crumb.path} className="text-blue-600 hover:underline">
+                {crumb.label}
+              </Link>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+};
+
+export default Breadcrumbs;

--- a/installer-app/src/components/layout/Header.tsx
+++ b/installer-app/src/components/layout/Header.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { FaBell, FaSearch, FaBars } from "react-icons/fa";
+import { useAuth } from "../../lib/hooks/useAuth";
+
+interface HeaderProps {
+  onToggleSidebar: () => void;
+}
+
+const dashboardPath: Record<string, string> = {
+  Admin: "/admin/dashboard",
+  Manager: "/manager/dashboard",
+  Sales: "/sales/dashboard",
+  Installer: "/installer/dashboard",
+};
+
+export const Header: React.FC<HeaderProps> = ({ onToggleSidebar }) => {
+  const { user, role, signOut } = useAuth();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const dashboard = dashboardPath[role ?? ""] || "/";
+
+  return (
+    <header className="bg-gray-800 text-white flex items-center justify-between px-4 py-2">
+      <div className="flex items-center gap-2">
+        <button
+          onClick={onToggleSidebar}
+          className="md:hidden text-xl focus:outline-none"
+          aria-label="Toggle Menu"
+        >
+          <FaBars />
+        </button>
+        <Link to={dashboard} className="text-lg font-bold">
+          SentientZone
+        </Link>
+      </div>
+      <div className="flex items-center gap-4 relative">
+        <button aria-label="Notifications" className="text-xl">
+          <FaBell />
+        </button>
+        <button aria-label="Search" className="text-xl">
+          <FaSearch />
+        </button>
+        <button
+          onClick={() => setMenuOpen(!menuOpen)}
+          className="text-sm font-semibold focus:outline-none"
+        >
+          {user?.email}
+        </button>
+        {menuOpen && (
+          <div className="absolute right-0 top-full mt-2 w-48 bg-white text-gray-800 rounded shadow z-10">
+            <Link to="/profile" className="block px-4 py-2 hover:bg-gray-100">
+              My Profile
+            </Link>
+            {user && (user as any).selected_role && (
+              <Link to="/switch-role" className="block px-4 py-2 hover:bg-gray-100">
+                Switch Role
+              </Link>
+            )}
+            <button
+              className="block w-full text-left px-4 py-2 hover:bg-gray-100"
+              onClick={signOut}
+            >
+              Logout
+            </button>
+          </div>
+        )}
+      </div>
+    </header>
+  );
+};
+
+export default Header;

--- a/installer-app/src/components/layout/Sidebar.tsx
+++ b/installer-app/src/components/layout/Sidebar.tsx
@@ -1,0 +1,97 @@
+import { useEffect } from "react";
+import { NavLink } from "react-router-dom";
+import { FaTimes } from "react-icons/fa";
+import { useAuth } from "../../lib/hooks/useAuth";
+
+interface SidebarProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface LinkItem {
+  to: string;
+  label: string;
+}
+
+const adminLinks: LinkItem[] = [
+  { to: "/admin/dashboard", label: "Dashboard" },
+  { to: "/clients", label: "Clients" },
+  { to: "/leads", label: "Leads" },
+  { to: "/quotes", label: "Quotes" },
+  { to: "/jobs", label: "Jobs" },
+  { to: "/invoices", label: "Invoices" },
+  { to: "/payments", label: "Payments" },
+  { to: "/reports", label: "Reports" },
+  { to: "/settings", label: "Settings" },
+];
+
+const managerLinks: LinkItem[] = [
+  { to: "/admin/dashboard", label: "Dashboard" },
+  { to: "/clients", label: "Clients" },
+  { to: "/leads", label: "Leads" },
+  { to: "/quotes", label: "Quotes" },
+  { to: "/jobs", label: "Jobs" },
+  { to: "/invoices", label: "Invoices" },
+  { to: "/payments", label: "Payments" },
+  { to: "/reports", label: "Reports" },
+  { to: "/settings", label: "Settings" },
+];
+
+const salesLinks: LinkItem[] = [
+  { to: "/sales/dashboard", label: "Dashboard" },
+  { to: "/leads", label: "Leads" },
+  { to: "/quotes", label: "Quotes" },
+  { to: "/clients", label: "Clients" },
+];
+
+const installerLinks: LinkItem[] = [
+  { to: "/installer/dashboard", label: "Dashboard" },
+  { to: "/installer/jobs", label: "My Jobs" },
+  { to: "/installer/materials", label: "Material Logger" },
+];
+
+function getLinks(role: string | null): LinkItem[] {
+  switch (role) {
+    case "Admin":
+      return adminLinks;
+    case "Manager":
+      return managerLinks;
+    case "Sales":
+      return salesLinks;
+    default:
+      return installerLinks;
+  }
+}
+
+export const Sidebar: React.FC<SidebarProps> = ({ open, onClose }) => {
+  const { role } = useAuth();
+  const links = getLinks(role);
+
+  useEffect(() => {
+    localStorage.setItem("sidebarOpen", open ? "true" : "false");
+  }, [open]);
+
+  return (
+    <aside
+      className={`bg-gray-800 text-white w-64 space-y-1 px-4 py-4 transform ${open ? "translate-x-0" : "-translate-x-full"} md:translate-x-0 transition-transform duration-200 fixed md:static inset-y-0 left-0 z-40`}
+    >
+      <button className="md:hidden mb-4" onClick={onClose} aria-label="Close Menu">
+        <FaTimes />
+      </button>
+      {links.map((link) => (
+        <NavLink
+          key={link.to}
+          to={link.to}
+          className={({ isActive }) =>
+            `block px-2 py-2 rounded hover:bg-gray-700 ${isActive ? "bg-gray-700" : ""}`
+          }
+          onClick={onClose}
+        >
+          {link.label}
+        </NavLink>
+      ))}
+    </aside>
+  );
+};
+
+export default Sidebar;

--- a/installer-app/src/lib/hooks/useJobDetail.ts
+++ b/installer-app/src/lib/hooks/useJobDetail.ts
@@ -3,7 +3,8 @@ import supabase from "../supabaseClient";
 
 export interface JobDetail {
   id: string;
-  clinic_name: string;
+  client_id: string | null;
+  client_name?: string | null;
   address: string;
   notes: string | null;
   status: string;
@@ -24,7 +25,7 @@ export default function useJobDetail(jobId: string | null) {
     setLoading(true);
     const { data, error } = await supabase
       .from("jobs")
-      .select("id, clinic_name, address, notes, status, assigned_to")
+      .select("id, client_id, address, notes, status, assigned_to, clients(name)")
       .eq("id", jobId)
       .single();
     if (error) {
@@ -32,7 +33,10 @@ export default function useJobDetail(jobId: string | null) {
       setJob(null);
     } else {
       setError(null);
-      setJob(data as JobDetail);
+      setJob({
+        ...(data as any),
+        client_name: (data as any).clients?.name ?? null,
+      } as JobDetail);
     }
     setLoading(false);
   }, [jobId]);

--- a/installer-app/src/lib/hooks/useJobs.ts
+++ b/installer-app/src/lib/hooks/useJobs.ts
@@ -3,7 +3,8 @@ import supabase from "../supabaseClient";
 
 export interface Job {
   id: string;
-  clinic_name: string;
+  client_id: string | null;
+  client_name?: string | null;
   contact_name: string;
   contact_phone: string;
   assigned_to: string | null;
@@ -20,16 +21,20 @@ export function useJobs() {
   const fetchJobs = useCallback(async () => {
     setLoading(true);
     const { data, error } = await supabase
-      .from<Job>("jobs")
+      .from("jobs")
       .select(
-        "id, clinic_name, contact_name, contact_phone, assigned_to, status, created_at, quote_id",
+        "id, client_id, contact_name, contact_phone, assigned_to, status, created_at, quote_id, clients(name)"
       )
       .order("created_at", { ascending: false });
     if (error) {
       setError(error.message);
       setJobs([]);
     } else {
-      setJobs(data ?? []);
+      const list = (data ?? []).map((j: any) => ({
+        ...j,
+        client_name: j.clients?.name ?? null,
+      }));
+      setJobs(list);
       setError(null);
     }
     setLoading(false);
@@ -38,9 +43,9 @@ export function useJobs() {
   const fetchMyJobs = useCallback(async (userId: string) => {
     setLoading(true);
     const { data, error } = await supabase
-      .from<Job>("jobs")
+      .from("jobs")
       .select(
-        "id, clinic_name, contact_name, contact_phone, assigned_to, status, created_at, quote_id",
+        "id, client_id, contact_name, contact_phone, assigned_to, status, created_at, quote_id, clients(name)"
       )
       .eq("assigned_to", userId)
       .order("created_at", { ascending: false });
@@ -48,7 +53,11 @@ export function useJobs() {
       setError(error.message);
       setJobs([]);
     } else {
-      setJobs(data ?? []);
+      const list = (data ?? []).map((j: any) => ({
+        ...j,
+        client_name: j.clients?.name ?? null,
+      }));
+      setJobs(list);
       setError(null);
     }
     setLoading(false);


### PR DESCRIPTION
## Summary
- add AppLayout with Header, Sidebar, and Breadcrumbs
- route all authenticated pages through layout
- switch job creation to use `client_id`
- update hooks and pages to drop deprecated `clinic_name`
- fix quote conversion workflow

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68581fb97158832d9aed203c9543b5a4