### PR TITLE
Add onboarding panel and user settings

### DIFF
--- a/installer-app/.storybook/main.ts
+++ b/installer-app/.storybook/main.ts
@@ -1,0 +1,14 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  addons: ['@storybook/addon-essentials'],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {},
+  },
+  docs: {
+    autodocs: true,
+  },
+};
+export default config;

--- a/installer-app/.storybook/preview.ts
+++ b/installer-app/.storybook/preview.ts
@@ -1,0 +1,10 @@
+import type { Preview } from '@storybook/react';
+import '../src/index.css';
+
+const preview: Preview = {
+  parameters: {
+    actions: { argTypesRegex: '^on[A-Z].*' },
+  },
+};
+
+export default preview;

--- a/installer-app/api/migrations/020_create_user_settings.sql
+++ b/installer-app/api/migrations/020_create_user_settings.sql
@@ -1,0 +1,20 @@
+create table if not exists user_settings (
+  user_id uuid primary key references auth.users(id),
+  onboarding_version int default 1,
+  onboarding_completed_tasks jsonb default '[]',
+  onboarding_dismissed_at timestamptz null
+);
+
+alter table user_settings enable row level security;
+
+-- read own settings
+create policy "User Settings Select" on user_settings
+  for select using (auth.uid() = user_id);
+
+-- allow insert if uid matches
+create policy "User Settings Insert" on user_settings
+  for insert with check (auth.uid() = user_id);
+
+-- allow update if uid matches
+create policy "User Settings Update" on user_settings
+  for update using (auth.uid() = user_id);

--- a/installer-app/package.json
+++ b/installer-app/package.json
@@ -36,6 +36,10 @@
     "jest-environment-jsdom": "^30.0.0",
     "prettier": "^3.2.5",
     "tailwindcss": "^3.4.4",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "@storybook/react-vite": "^7.6.15",
+    "@storybook/addon-essentials": "^7.6.15",
+    "@storybook/react": "^7.6.15",
+    "dotenv": "^10.0.0"
   }
 }

--- a/installer-app/scripts/seedUserSettings.cjs
+++ b/installer-app/scripts/seedUserSettings.cjs
@@ -1,0 +1,25 @@
+const { createClient } = require("@supabase/supabase-js");
+require("dotenv").config({ path: "../.env" });
+
+const url = process.env.VITE_SUPABASE_URL;
+const key = process.env.VITE_SUPABASE_API_KEY;
+
+if (!url || !key) {
+  console.error("Missing Supabase env");
+  process.exit(1);
+}
+
+const supabase = createClient(url, key);
+
+async function seed() {
+  const { data: users } = await supabase.from("users").select("id").limit(5);
+  for (const u of users || []) {
+    await supabase.from("user_settings").upsert({ user_id: u.id });
+    console.log("Seeded settings for", u.id);
+  }
+}
+
+seed().then(() => {
+  console.log("done");
+  process.exit(0);
+});

--- a/installer-app/src/app/clients/ClientProfilePage.jsx
+++ b/installer-app/src/app/clients/ClientProfilePage.jsx
@@ -7,18 +7,23 @@ import { useJobs } from '../../lib/hooks/useJobs';
 import useInvoices from '../../lib/hooks/useInvoices';
 import usePayments from '../../lib/hooks/usePayments';
 import { SZTable } from '../../components/ui/SZTable';
+import { LoadingState, EmptyState, ErrorState } from '../../components/ui/state';
 
 export default function ClientProfilePage() {
   const { role } = useAuth();
   const { id } = useParams();
-  const [clients] = useClients();
-  const [quotes] = useQuotes();
-  const { jobs } = useJobs();
-  const [invoices] = useInvoices();
-  const [payments] = usePayments();
+  const [clients, { loading: clientsLoading, error: clientsError }] = useClients();
+  const [quotes, { loading: quotesLoading, error: quotesError }] = useQuotes();
+  const { jobs, loading: jobsLoading, error: jobsError } = useJobs();
+  const [invoices, { loading: invoicesLoading, error: invoicesError }] = useInvoices();
+  const [payments, { loading: paymentsLoading, error: paymentsError }] = usePayments();
   const client = clients.find(c => c.id === id);
 
   if (!role) return null;
+  if (clientsLoading || quotesLoading || jobsLoading || invoicesLoading || paymentsLoading)
+    return <LoadingState type="detail" />;
+  if (clientsError || quotesError || jobsError || invoicesError || paymentsError)
+    return <ErrorState message={clientsError || quotesError || jobsError || invoicesError || paymentsError} />;
   if (!client) return <div className="p-4">Client not found</div>;
 
   const clientQuotes = quotes.filter(q => q.client_id === id);
@@ -36,49 +41,65 @@ export default function ClientProfilePage() {
       </div>
       <section>
         <h2 className="font-semibold">Quotes</h2>
-        <SZTable headers={["Title", "Status", "Total"]}>
-          {clientQuotes.map(q => (
-            <tr key={q.id} className="border-t">
-              <td className="p-2 border">{q.title}</td>
-              <td className="p-2 border">{q.status}</td>
-              <td className="p-2 border">${(q.total ?? 0).toFixed(2)}</td>
-            </tr>
-          ))}
-        </SZTable>
+        {clientQuotes.length === 0 ? (
+          <EmptyState title="No Quotes" />
+        ) : (
+          <SZTable headers={["Title", "Status", "Total"]}>
+            {clientQuotes.map(q => (
+              <tr key={q.id} className="border-t">
+                <td className="p-2 border">{q.title}</td>
+                <td className="p-2 border">{q.status}</td>
+                <td className="p-2 border">${(q.total ?? 0).toFixed(2)}</td>
+              </tr>
+            ))}
+          </SZTable>
+        )}
       </section>
       <section>
         <h2 className="font-semibold">Jobs</h2>
-        <SZTable headers={["Clinic", "Status"]}>
-          {clientJobs.map(j => (
-            <tr key={j.id} className="border-t">
-              <td className="p-2 border">{j.clinic_name}</td>
-              <td className="p-2 border">{j.status}</td>
-            </tr>
-          ))}
-        </SZTable>
+        {clientJobs.length === 0 ? (
+          <EmptyState title="No Jobs" />
+        ) : (
+          <SZTable headers={["Clinic", "Status"]}>
+            {clientJobs.map(j => (
+              <tr key={j.id} className="border-t">
+                <td className="p-2 border">{j.clinic_name}</td>
+                <td className="p-2 border">{j.status}</td>
+              </tr>
+            ))}
+          </SZTable>
+        )}
       </section>
       <section>
         <h2 className="font-semibold">Invoices</h2>
-        <SZTable headers={["Amount", "Status"]}>
-          {clientInvoices.map(i => (
-            <tr key={i.id} className="border-t">
-              <td className="p-2 border">${i.amount.toFixed(2)}</td>
-              <td className="p-2 border">{i.status}</td>
-            </tr>
-          ))}
-        </SZTable>
+        {clientInvoices.length === 0 ? (
+          <EmptyState title="No Invoices" />
+        ) : (
+          <SZTable headers={["Amount", "Status"]}>
+            {clientInvoices.map(i => (
+              <tr key={i.id} className="border-t">
+                <td className="p-2 border">${i.amount.toFixed(2)}</td>
+                <td className="p-2 border">{i.status}</td>
+              </tr>
+            ))}
+          </SZTable>
+        )}
       </section>
       <section>
         <h2 className="font-semibold">Payments</h2>
-        <SZTable headers={["Amount", "Method", "Date"]}>
-          {clientPayments.map(p => (
-            <tr key={p.id} className="border-t">
-              <td className="p-2 border">${p.amount.toFixed(2)}</td>
-              <td className="p-2 border">{p.method}</td>
-              <td className="p-2 border">{new Date(p.received_at).toLocaleDateString()}</td>
-            </tr>
-          ))}
-        </SZTable>
+        {clientPayments.length === 0 ? (
+          <EmptyState title="No Payments" />
+        ) : (
+          <SZTable headers={["Amount", "Method", "Date"]}>
+            {clientPayments.map(p => (
+              <tr key={p.id} className="border-t">
+                <td className="p-2 border">${p.amount.toFixed(2)}</td>
+                <td className="p-2 border">{p.method}</td>
+                <td className="p-2 border">{new Date(p.received_at).toLocaleDateString()}</td>
+              </tr>
+            ))}
+          </SZTable>
+        )}
       </section>
     </div>
   );

--- a/installer-app/src/app/invoices/InvoicesPage.tsx
+++ b/installer-app/src/app/invoices/InvoicesPage.tsx
@@ -3,9 +3,13 @@ import { SZButton } from "../../components/ui/SZButton";
 import { SZTable } from "../../components/ui/SZTable";
 import useInvoices from "../../lib/hooks/useInvoices";
 import InvoiceFormModal, { InvoiceData } from "../../components/modals/InvoiceFormModal";
+import { LoadingState, EmptyState, ErrorState } from "../../components/ui/state";
 
 const InvoicesPage: React.FC = () => {
-  const [invoices, { createInvoice, updateInvoice }] = useInvoices();
+  const [
+    invoices,
+    { loading, error, fetchInvoices, createInvoice, updateInvoice },
+  ] = useInvoices();
   const [filter, setFilter] = useState<"all" | "paid" | "unpaid" | "partially_paid">("all");
   const [open, setOpen] = useState(false);
 
@@ -46,23 +50,30 @@ const InvoicesPage: React.FC = () => {
           </SZButton>
         </div>
       </div>
-      <SZTable headers={["Invoice", "Client", "Amount", "Status", "Actions"]}>
-        {filtered.map((inv) => (
-          <tr key={inv.id} className="border-t">
-            <td className="p-2 border">{inv.id}</td>
-            <td className="p-2 border">{inv.client_name}</td>
-            <td className="p-2 border">${inv.amount.toFixed(2)}</td>
-            <td className="p-2 border">{inv.status}</td>
-            <td className="p-2 border">
-              {inv.status !== "paid" && (
-                <SZButton size="sm" onClick={() => markPaid(inv.id)}>
-                  Mark Paid
-                </SZButton>
-              )}
-            </td>
-          </tr>
-        ))}
-      </SZTable>
+      {loading && <LoadingState type="list" />}
+      {error && <ErrorState message={error} onRetry={fetchInvoices} />}
+      {!loading && !error && filtered.length === 0 && (
+        <EmptyState title="No Invoices" description="No invoices found for this filter." />
+      )}
+      {!loading && !error && filtered.length > 0 && (
+        <SZTable headers={["Invoice", "Client", "Amount", "Status", "Actions"]}>
+          {filtered.map((inv) => (
+            <tr key={inv.id} className="border-t">
+              <td className="p-2 border">{inv.id}</td>
+              <td className="p-2 border">{inv.client_name}</td>
+              <td className="p-2 border">${inv.amount.toFixed(2)}</td>
+              <td className="p-2 border">{inv.status}</td>
+              <td className="p-2 border">
+                {inv.status !== "paid" && (
+                  <SZButton size="sm" onClick={() => markPaid(inv.id)}>
+                    Mark Paid
+                  </SZButton>
+                )}
+              </td>
+            </tr>
+          ))}
+        </SZTable>
+      )}
       <InvoiceFormModal isOpen={open} onClose={() => setOpen(false)} onSave={handleSave} />
     </div>
   );

--- a/installer-app/src/app/quotes/QuotesPage.tsx
+++ b/installer-app/src/app/quotes/QuotesPage.tsx
@@ -4,9 +4,13 @@ import { SZTable } from "../../components/ui/SZTable";
 import QuoteFormModal, { QuoteData } from "../../components/modals/QuoteFormModal";
 import { useJobs } from "../../lib/hooks/useJobs";
 import useQuotes from "../../lib/hooks/useQuotes";
+import { LoadingState, EmptyState, ErrorState } from "../../components/ui/state";
 
 const QuotesPage: React.FC = () => {
-  const [quotes, { createQuote, updateQuote, deleteQuote }] = useQuotes();
+  const [
+    quotes,
+    { loading, error, fetchQuotes, createQuote, updateQuote, deleteQuote },
+  ] = useQuotes();
   const [active, setActive] = useState<
     (QuoteData & { status?: string }) | null
   >(null);
@@ -70,39 +74,54 @@ const QuotesPage: React.FC = () => {
           New Quote
         </SZButton>
       </div>
-      <SZTable headers={["Client", "Total", "Status", "Actions"]}>
-        {quotes.map((q) => (
-          <tr key={q.id} className="border-t">
-            <td className="p-2 border">{q.client_name}</td>
-            <td className="p-2 border">${(q.total ?? 0).toFixed(2)}</td>
-            <td className="p-2 border">{q.status}</td>
-            <td className="p-2 border space-x-2">
-              {q.status === "draft" || q.status === "pending" ? (
-                <SZButton size="sm" onClick={() => approve(q.id!)}>
-                  Approve
+      {loading && <LoadingState type="list" />}
+      {error && <ErrorState message={error} onRetry={fetchQuotes} />}
+      {!loading && !error && quotes.length === 0 && (
+        <EmptyState
+          title="No Quotes Found"
+          description="You haven\u2019t created any quotes yet."
+          actionLabel="Create Quote"
+          onAction={() => {
+            setActive(null);
+            setOpen(true);
+          }}
+        />
+      )}
+      {!loading && !error && quotes.length > 0 && (
+        <SZTable headers={["Client", "Total", "Status", "Actions"]}>
+          {quotes.map((q) => (
+            <tr key={q.id} className="border-t">
+              <td className="p-2 border">{q.client_name}</td>
+              <td className="p-2 border">${(q.total ?? 0).toFixed(2)}</td>
+              <td className="p-2 border">{q.status}</td>
+              <td className="p-2 border space-x-2">
+                {q.status === "draft" || q.status === "pending" ? (
+                  <SZButton size="sm" onClick={() => approve(q.id!)}>
+                    Approve
+                  </SZButton>
+                ) : null}
+                <SZButton
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => {
+                    setActive(q);
+                    setOpen(true);
+                  }}
+                >
+                  Edit
                 </SZButton>
-              ) : null}
-              <SZButton
-                size="sm"
-                variant="secondary"
-                onClick={() => {
-                  setActive(q);
-                  setOpen(true);
-                }}
-              >
-                Edit
-              </SZButton>
-              <SZButton
-                size="sm"
-                variant="destructive"
-                onClick={() => deleteQuote(q.id)}
-              >
-                Delete
-              </SZButton>
-            </td>
-          </tr>
-        ))}
-      </SZTable>
+                <SZButton
+                  size="sm"
+                  variant="destructive"
+                  onClick={() => deleteQuote(q.id)}
+                >
+                  Delete
+                </SZButton>
+              </td>
+            </tr>
+          ))}
+        </SZTable>
+      )}
       <QuoteFormModal
         isOpen={open}
         onClose={() => setOpen(false)}

--- a/installer-app/src/components/navigation/GlobalLayout.tsx
+++ b/installer-app/src/components/navigation/GlobalLayout.tsx
@@ -3,6 +3,7 @@ import { Outlet } from "react-router-dom";
 import Header from "./Header";
 import Sidebar from "./Sidebar";
 import Breadcrumbs from "./Breadcrumbs";
+import OnboardingPanel from "../onboarding/OnboardingPanel";
 
 const GlobalLayout: React.FC = () => {
   const [open, setOpen] = useState(true);
@@ -25,6 +26,7 @@ const GlobalLayout: React.FC = () => {
         <Header onToggleSidebar={toggle} />
         <Breadcrumbs />
         <main className="flex-1 overflow-y-auto p-4 bg-gray-100">
+          <OnboardingPanel />
           <Outlet />
         </main>
       </div>

--- a/installer-app/src/components/onboarding/OnboardingPanel.tsx
+++ b/installer-app/src/components/onboarding/OnboardingPanel.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import useOnboardingStatus from "../../lib/hooks/useOnboardingStatus";
+import { useAuth } from "../../lib/hooks/useAuth";
+
+const tasksByRole: Record<string, { id: string; label: string; to: string }[]> =
+  {
+    Admin: [
+      { id: "company-profile", label: "Set up Company Profile", to: "#" },
+      { id: "add-team", label: "Add Team Member", to: "#" },
+      { id: "service-types", label: "Define Service Types", to: "/quotes/new" },
+      { id: "view-kpis", label: "View KPIs", to: "/admin/dashboard" },
+    ],
+    Sales: [
+      { id: "add-lead", label: "Add Lead", to: "/crm/leads" },
+      { id: "create-quote", label: "Create Quote", to: "/quotes/new" },
+      { id: "open-crm", label: "Open CRM Pipeline", to: "/crm/leads" },
+    ],
+    Manager: [
+      { id: "view-jobs", label: "View Jobs", to: "/install-manager/dashboard" },
+      { id: "review-quotes", label: "Review Quotes", to: "/quotes" },
+      { id: "payroll", label: "Generate Payroll Report", to: "/reports" },
+    ],
+    Installer: [
+      {
+        id: "assigned-jobs",
+        label: "View Assigned Jobs",
+        to: "/installer/dashboard",
+      },
+      { id: "test-job", label: "Complete Test Job", to: "/mock-jobs" },
+      { id: "log-materials", label: "Log Materials", to: "/installer/jobs/1" },
+    ],
+  };
+
+const OnboardingPanel: React.FC = () => {
+  const { role, user } = useAuth();
+  const { status, markComplete, dismiss, progress } = useOnboardingStatus();
+
+  if (!role || !user) return null;
+  if (status && status.dismissedAt) return null;
+
+  const tasks = tasksByRole[role] || [];
+  const completed = new Set(status?.completedTasks ?? []);
+  const doneCount = [...completed].length;
+
+  if (doneCount >= tasks.length) return null;
+
+  return (
+    <div className="bg-white rounded-xl shadow p-4 mb-4">
+      <div className="flex justify-between items-center mb-2">
+        <h2 className="font-semibold text-lg">
+          Welcome, {user.user_metadata?.full_name || user.email}! Let’s get you
+          set up.
+        </h2>
+        <button onClick={dismiss} className="text-sm text-gray-500">
+          Dismiss
+        </button>
+      </div>
+      <div className="mb-2 text-sm text-gray-600">
+        {doneCount}/{tasks.length} tasks complete
+      </div>
+      <ul className="space-y-2">
+        {tasks.map((t) => (
+          <li key={t.id} className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={completed.has(t.id)}
+              onChange={() => markComplete(t.id)}
+              className="h-4 w-4"
+            />
+            <Link to={t.to} className="text-green-600 hover:underline">
+              {t.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default OnboardingPanel;

--- a/installer-app/src/components/onboarding/index.ts
+++ b/installer-app/src/components/onboarding/index.ts
@@ -1,0 +1,1 @@
+export { default as OnboardingPanel } from "./OnboardingPanel";

--- a/installer-app/src/components/ui/state/EmptyState.stories.tsx
+++ b/installer-app/src/components/ui/state/EmptyState.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { EmptyState } from './EmptyState';
+
+const meta: Meta<typeof EmptyState> = {
+  title: 'UI/State/EmptyState',
+  component: EmptyState,
+  tags: ['autodocs'],
+};
+export default meta;
+
+export const Basic: StoryObj<typeof EmptyState> = {
+  args: {
+    title: 'No Items',
+    description: 'There is nothing here yet.',
+  },
+};
+
+export const WithAction: StoryObj<typeof EmptyState> = {
+  args: {
+    title: 'No Quotes Found',
+    actionLabel: 'Create Quote',
+  },
+};

--- a/installer-app/src/components/ui/state/EmptyState.tsx
+++ b/installer-app/src/components/ui/state/EmptyState.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { FaInbox } from 'react-icons/fa';
+
+export type EmptyStateProps = {
+  title: string;
+  description?: string;
+  actionLabel?: string;
+  onAction?: () => void;
+  icon?: React.ReactNode;
+};
+
+export const EmptyState: React.FC<EmptyStateProps> = ({
+  title,
+  description,
+  actionLabel,
+  onAction,
+  icon,
+}) => {
+  return (
+    <div className="flex flex-col items-center text-center p-6 bg-white rounded-xl shadow">
+      <div className="text-gray-400 mb-4 text-4xl">
+        {icon ?? <FaInbox />}
+      </div>
+      <h3 className="font-semibold text-gray-900 mb-1">{title}</h3>
+      {description && <p className="text-gray-500 text-sm mb-3">{description}</p>}
+      {actionLabel && onAction && (
+        <button
+          className="mt-2 px-4 py-2 bg-green-600 text-white rounded"
+          onClick={onAction}
+        >
+          {actionLabel}
+        </button>
+      )}
+    </div>
+  );
+};

--- a/installer-app/src/components/ui/state/ErrorState.stories.tsx
+++ b/installer-app/src/components/ui/state/ErrorState.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ErrorState } from './ErrorState';
+
+const meta: Meta<typeof ErrorState> = {
+  title: 'UI/State/ErrorState',
+  component: ErrorState,
+  tags: ['autodocs'],
+};
+export default meta;
+
+export const Basic: StoryObj<typeof ErrorState> = {
+  args: {},
+};
+
+export const CustomMessage: StoryObj<typeof ErrorState> = {
+  args: { message: 'Failed to fetch data' },
+};

--- a/installer-app/src/components/ui/state/ErrorState.tsx
+++ b/installer-app/src/components/ui/state/ErrorState.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { FaExclamationCircle } from 'react-icons/fa';
+
+export type ErrorStateProps = {
+  message?: string;
+  onRetry?: () => void;
+  icon?: React.ReactNode;
+};
+
+export const ErrorState: React.FC<ErrorStateProps> = ({
+  message = 'Something went wrong',
+  onRetry,
+  icon,
+}) => {
+  return (
+    <div className="flex flex-col items-center text-center p-6 bg-white rounded-xl shadow">
+      <div className="text-red-500 mb-4 text-4xl">
+        {icon ?? <FaExclamationCircle />}
+      </div>
+      <p className="text-gray-700 mb-3">{message}</p>
+      {onRetry && (
+        <button
+          className="px-4 py-2 bg-green-600 text-white rounded"
+          onClick={onRetry}
+        >
+          Try Again
+        </button>
+      )}
+    </div>
+  );
+};

--- a/installer-app/src/components/ui/state/LoadingState.stories.tsx
+++ b/installer-app/src/components/ui/state/LoadingState.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { LoadingState } from './LoadingState';
+
+const meta: Meta<typeof LoadingState> = {
+  title: 'UI/State/LoadingState',
+  component: LoadingState,
+  tags: ['autodocs'],
+};
+export default meta;
+
+export const List: StoryObj<typeof LoadingState> = {
+  args: { type: 'list' },
+};
+
+export const Detail: StoryObj<typeof LoadingState> = {
+  args: { type: 'detail' },
+};
+
+export const Inline: StoryObj<typeof LoadingState> = {
+  args: { type: 'inline', message: 'Loading...' },
+};

--- a/installer-app/src/components/ui/state/LoadingState.tsx
+++ b/installer-app/src/components/ui/state/LoadingState.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+export type LoadingStateProps = {
+  type?: 'list' | 'detail' | 'inline';
+  message?: string;
+};
+
+export const LoadingState: React.FC<LoadingStateProps> = ({
+  type = 'inline',
+  message,
+}) => {
+  if (type === 'inline') {
+    return (
+      <div className="flex items-center justify-center p-4" aria-label="Loading">
+        <svg
+          className="animate-spin h-5 w-5 text-gray-500 mr-2"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+          />
+        </svg>
+        {message && <span className="text-gray-500 text-sm">{message}</span>}
+      </div>
+    );
+  }
+
+  const rows = type === 'list' ? 5 : 3;
+  return (
+    <div className="space-y-2 p-4 animate-pulse" aria-label="Loading">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div
+          key={i}
+          className="h-4 bg-gray-200 rounded w-full"
+          style={{ height: type === 'detail' ? '1.5rem' : '1rem' }}
+        />
+      ))}
+    </div>
+  );
+};

--- a/installer-app/src/components/ui/state/index.ts
+++ b/installer-app/src/components/ui/state/index.ts
@@ -1,0 +1,3 @@
+export { LoadingState } from './LoadingState';
+export { EmptyState } from './EmptyState';
+export { ErrorState } from './ErrorState';

--- a/installer-app/src/installer/pages/JobListPage.jsx
+++ b/installer-app/src/installer/pages/JobListPage.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import useAssignedJobs from "../hooks/useAssignedJobs";
+import { LoadingState, EmptyState, ErrorState } from "../../components/ui/state";
 
 const statusStyles = {
   assigned: "bg-gray-400",
@@ -17,10 +18,10 @@ export default function JobListPage() {
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">Assigned Jobs</h1>
 
-      {loading && <p>Loading jobs...</p>}
-      {error && <p className="text-red-500">{error}</p>}
-
-      {!loading && !error && (
+      {loading && <LoadingState type="list" />}
+      {error && <ErrorState message={error} />}
+      {!loading && !error && jobs.length === 0 && <EmptyState title="No Jobs" />}
+      {!loading && !error && jobs.length > 0 && (
         <ul className="space-y-4">
           {jobs.map((job) => (
             <li

--- a/installer-app/src/lib/hooks/useOnboardingStatus.ts
+++ b/installer-app/src/lib/hooks/useOnboardingStatus.ts
@@ -1,0 +1,97 @@
+import { useState, useEffect, useCallback } from "react";
+import supabase from "../supabaseClient";
+import { useAuth } from "./useAuth";
+
+export interface OnboardingStatus {
+  completedTasks: string[];
+  dismissedAt: string | null;
+}
+
+export function useOnboardingStatus() {
+  const { user } = useAuth();
+  const [status, setStatus] = useState<OnboardingStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStatus = useCallback(async () => {
+    if (!user) return;
+    setLoading(true);
+    const { data, error } = await supabase
+      .from("user_settings")
+      .select("onboarding_completed_tasks, onboarding_dismissed_at")
+      .eq("user_id", user.id)
+      .single();
+    if (error) {
+      if (error.code === "PGRST116") {
+        // no record
+        setStatus({ completedTasks: [], dismissedAt: null });
+        setError(null);
+      } else {
+        setError(error.message);
+        setStatus(null);
+      }
+    } else {
+      setStatus({
+        completedTasks: data.onboarding_completed_tasks ?? [],
+        dismissedAt: data.onboarding_dismissed_at,
+      });
+      setError(null);
+    }
+    setLoading(false);
+  }, [user]);
+
+  const markComplete = useCallback(
+    async (taskId: string) => {
+      if (!user) return;
+      const current = status?.completedTasks ?? [];
+      if (current.includes(taskId)) return;
+      const next = [...current, taskId];
+      setStatus((s) =>
+        s
+          ? { ...s, completedTasks: next }
+          : { completedTasks: next, dismissedAt: null },
+      );
+      await supabase.from("user_settings").upsert(
+        {
+          user_id: user.id,
+          onboarding_completed_tasks: next,
+        },
+        { onConflict: "user_id" },
+      );
+    },
+    [user, status],
+  );
+
+  const dismiss = useCallback(async () => {
+    if (!user) return;
+    const now = new Date().toISOString();
+    setStatus((s) =>
+      s ? { ...s, dismissedAt: now } : { completedTasks: [], dismissedAt: now },
+    );
+    await supabase.from("user_settings").upsert(
+      {
+        user_id: user.id,
+        onboarding_dismissed_at: now,
+      },
+      { onConflict: "user_id" },
+    );
+  }, [user]);
+
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  const progress = status ? status.completedTasks.length : 0;
+
+  return {
+    status,
+    loading,
+    error,
+    fetchStatus,
+    markComplete,
+    dismiss,
+    progress,
+  } as const;
+}
+
+export default useOnboardingStatus;


### PR DESCRIPTION
## Summary
- create onboarding panel component and hook
- add migration and seed script for user_settings table
- expose OnboardingPanel in GlobalLayout
- register dotenv as dev dependency

## Testing
- `npm test` *(fails: missing modules & env vars)*

------
https://chatgpt.com/codex/tasks/task_e_685823fca528832d96ffa8abbf51f1f9