### PR TITLE
Fix Supabase env var names

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This repository contains the Vite + React Installer App located in the `installe
    ```bash
    echo "VITE_SUPABASE_URL=YOUR_SUPABASE_URL" >> .env
    echo "VITE_SUPABASE_API_KEY=YOUR_SUPABASE_ANON_KEY" >> .env
+   # or VITE_SUPABASE_ANON_KEY
    ```
 
 4. **Start the dev server:**

--- a/installer-app/README.md
+++ b/installer-app/README.md
@@ -76,8 +76,10 @@ index.html             // Vite HTML entry
 
 Required:
 - `VITE_SUPABASE_URL`
-- `VITE_SUPABASE_API_KEY`
+- `VITE_SUPABASE_API_KEY` or `VITE_SUPABASE_ANON_KEY`
 
-Optional (for compatibility only; Vite uses VITE_ prefix):
+Optional (for compatibility only; values fall back automatically):
 - `NEXT_PUBLIC_SUPABASE_URL`
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_URL`
+- `SUPABASE_ANON_KEY`

--- a/installer-app/api/feedback.js
+++ b/installer-app/api/feedback.js
@@ -1,9 +1,14 @@
 import { createClient } from "@supabase/supabase-js";
 
 const supabaseUrl =
-  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  process.env.VITE_SUPABASE_URL ||
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  process.env.SUPABASE_URL;
 const supabaseAnonKey =
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_API_KEY;
+  process.env.VITE_SUPABASE_API_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  process.env.SUPABASE_ANON_KEY;
 
 const supabase = createClient(supabaseUrl, supabaseAnonKey);
 

--- a/installer-app/api/jobs/[id]/checklist.js
+++ b/installer-app/api/jobs/[id]/checklist.js
@@ -1,10 +1,14 @@
 import { createClient } from "@supabase/supabase-js";
 
 const supabaseUrl =
-  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  process.env.VITE_SUPABASE_URL ||
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  process.env.SUPABASE_URL;
 const supabaseAnonKey =
+  process.env.VITE_SUPABASE_API_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-  process.env.VITE_SUPABASE_API_KEY;
+  process.env.SUPABASE_ANON_KEY;
 
 const supabase = createClient(supabaseUrl, supabaseAnonKey);
 

--- a/installer-app/src/installer/components/DocumentViewerModal.jsx
+++ b/installer-app/src/installer/components/DocumentViewerModal.jsx
@@ -11,6 +11,7 @@ const DocumentViewerModal = ({ isOpen, onClose, documents = [] }) => {
       const base =
         process.env.VITE_SUPABASE_URL ||
         process.env.NEXT_PUBLIC_SUPABASE_URL ||
+        process.env.SUPABASE_URL ||
         "";
       return `${base}/storage/v1/object/public/documents/${doc.path}`;
     }

--- a/installer-app/src/lib/authHelpers.ts
+++ b/installer-app/src/lib/authHelpers.ts
@@ -1,9 +1,26 @@
+import supabase, { SUPABASE_URL, SUPABASE_ANON_KEY } from './supabaseClient';
+
 export async function getUserRole(userId: string): Promise<string | null> {
-  const { default: supabase } = await import('./supabaseClient');
-  const { data } = await supabase
-    .from('user_roles')
-    .select('role')
-    .eq('user_id', userId)
-    .single();
-  return data?.role ?? null;
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  const res = await fetch(
+    `${SUPABASE_URL}/rest/v1/user_roles?select=role&user_id=eq.${userId}`,
+    {
+      headers: {
+        apikey: SUPABASE_ANON_KEY,
+        Authorization: session ? `Bearer ${session.access_token}` : undefined,
+        Accept: 'application/json',
+      },
+    }
+  );
+
+  if (!res.ok) {
+    console.error('Failed to fetch user role', await res.text());
+    return null;
+  }
+
+  const data = await res.json();
+  return data?.[0]?.role ?? null;
 }

--- a/installer-app/src/lib/supabaseClient.ts
+++ b/installer-app/src/lib/supabaseClient.ts
@@ -1,17 +1,33 @@
 import { createClient } from "@supabase/supabase-js";
 
-// Ensure these are populated in `.env.local`:
-// NEXT_PUBLIC_SUPABASE_URL=https://your-project-id.supabase.co
-// NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
+// Ensure these are populated in `.env.local` or your hosting provider:
+// VITE_SUPABASE_URL=https://your-project-id.supabase.co
+// VITE_SUPABASE_API_KEY=your-anon-key-here
+// (also reads NEXT_PUBLIC_ or un-prefixed variants for compatibility)
 
 // Read credentials from environment variables (works in both Vite and Node)
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = process.env.VITE_SUPABASE_ANON_KEY;
+const supabaseUrl =
+  process.env.VITE_SUPABASE_URL ||
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  process.env.SUPABASE_URL;
+const supabaseAnonKey =
+  process.env.VITE_SUPABASE_API_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  process.env.SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseAnonKey) {
   console.error("Missing Supabase credentials", { supabaseUrl, supabaseAnonKey });
   throw new Error("Supabase environment variables are missing. Check your .env.local file.");
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  global: {
+    headers: {
+      Accept: "application/json",
+    },
+  },
+});
+export const SUPABASE_URL = supabaseUrl;
+export const SUPABASE_ANON_KEY = supabaseAnonKey;
 export default supabase;

--- a/installer-app/vite.config.js
+++ b/installer-app/vite.config.js
@@ -7,6 +7,11 @@ export default defineConfig({
   define: {
     'process.env.VITE_SUPABASE_URL': JSON.stringify(process.env.VITE_SUPABASE_URL),
     'process.env.VITE_SUPABASE_API_KEY': JSON.stringify(process.env.VITE_SUPABASE_API_KEY),
+    'process.env.VITE_SUPABASE_ANON_KEY': JSON.stringify(process.env.VITE_SUPABASE_ANON_KEY),
+    'process.env.NEXT_PUBLIC_SUPABASE_URL': JSON.stringify(process.env.NEXT_PUBLIC_SUPABASE_URL),
+    'process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY': JSON.stringify(process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY),
+    'process.env.SUPABASE_URL': JSON.stringify(process.env.SUPABASE_URL),
+    'process.env.SUPABASE_ANON_KEY': JSON.stringify(process.env.SUPABASE_ANON_KEY),
   },
   optimizeDeps: {
     esbuildOptions: {


### PR DESCRIPTION
## Summary
- support multiple env variable names for Supabase client
- include fallback env vars in Node API handlers and document viewer
- expose NEXT_PUBLIC and fallback env vars in Vite config
- document additional env variable options
- ensure Supabase REST fetch sets `Accept: application/json` header

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685824ccd298832daee892da353ee4e4