### PR TITLE
Add OnboardingPanel UX feature

### DIFF
--- a/installer-app/api/migrations/020_create_user_settings.sql
+++ b/installer-app/api/migrations/020_create_user_settings.sql
@@ -1,0 +1,6 @@
+create table if not exists user_settings (
+  user_id uuid primary key references auth.users(id),
+  onboarding_version int default 1,
+  onboarding_completed_tasks jsonb default '[]',
+  onboarding_dismissed_at timestamptz
+);

--- a/installer-app/src/app/admin/AdminDashboard.jsx
+++ b/installer-app/src/app/admin/AdminDashboard.jsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import useAuth from '../../lib/hooks/useAuth';
 import useKPIs from '../../lib/hooks/useKPIs';
+import OnboardingPanel from '../../components/onboarding/OnboardingPanel';
 
 export default function AdminDashboard() {
-  const { role } = useAuth();
+  const { role, user } = useAuth();
   const kpis = useKPIs();
 
   if (role !== 'Admin') return <div className="p-4">Access denied</div>;
 
   return (
     <div className="p-4 space-y-4">
+      <OnboardingPanel role={role} userId={user?.id ?? null} />
       <h1 className="text-2xl font-bold">Business KPIs</h1>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <div className="p-4 bg-white rounded shadow">

--- a/installer-app/src/app/install-manager/page.jsx
+++ b/installer-app/src/app/install-manager/page.jsx
@@ -3,6 +3,8 @@ import JobCard from "../../components/JobCard";
 import { SZButton } from "../../components/ui/SZButton";
 import supabase from "../../lib/supabaseClient";
 import { useJobs } from "./useJobs";
+import { useAuth } from "../../lib/hooks/useAuth";
+import OnboardingPanel from "../../components/onboarding/OnboardingPanel";
 import EditJobModal from "./EditJobModal";
 import ConfirmDeleteModal from "./ConfirmDeleteModal";
 import QAReviewPanel from "./QAReviewPanel";
@@ -14,6 +16,7 @@ import JobCloseoutPanel from "./JobCloseoutPanel";
 
 export default function InstallManagerDashboard() {
   const { jobs, loading, error, refresh } = useJobs();
+  const { role, user } = useAuth();
   const navigate = useNavigate();
   const [editJob, setEditJob] = useState(null);
   const [deleteJob, setDeleteJob] = useState(null);
@@ -34,6 +37,7 @@ export default function InstallManagerDashboard() {
           New Job
         </SZButton>
       </header>
+      <OnboardingPanel role={role} userId={user?.id ?? null} />
       {loading && <div>Loading...</div>}
       {error && <div className="text-red-600">{error}</div>}
       <ul className="space-y-4">

--- a/installer-app/src/app/installer/InstallerDashboard.tsx
+++ b/installer-app/src/app/installer/InstallerDashboard.tsx
@@ -2,9 +2,10 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { useJobs } from "../../lib/hooks/useJobs";
 import { useAuth } from "../../lib/hooks/useAuth";
+import OnboardingPanel from "../../components/onboarding/OnboardingPanel";
 
 const InstallerDashboard: React.FC = () => {
-  const { session } = useAuth();
+  const { session, role, user } = useAuth();
   const currentUserId = session?.user?.id;
   const { jobs, loading } = useJobs();
   const myJobs = jobs.filter(
@@ -17,6 +18,7 @@ const InstallerDashboard: React.FC = () => {
 
   return (
     <div className="p-4 space-y-4">
+      <OnboardingPanel role={role} userId={user?.id ?? null} />
       <h1 className="text-2xl font-bold">Assigned Jobs</h1>
       <ul className="space-y-2">
         {myJobs.map((j) => (

--- a/installer-app/src/app/sales/SalesDashboard.tsx
+++ b/installer-app/src/app/sales/SalesDashboard.tsx
@@ -1,8 +1,12 @@
 import React from "react";
+import { useAuth } from "../../lib/hooks/useAuth";
+import OnboardingPanel from "../../components/onboarding/OnboardingPanel";
 
 const SalesDashboard: React.FC = () => {
+  const { role, user } = useAuth();
   return (
     <div className="p-4 space-y-4">
+      <OnboardingPanel role={role} userId={user?.id ?? null} />
       <h1 className="text-2xl font-bold">Sales Dashboard</h1>
       <p>Welcome to the sales dashboard.</p>
     </div>

--- a/installer-app/src/components/onboarding/OnboardingPanel.tsx
+++ b/installer-app/src/components/onboarding/OnboardingPanel.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { useAuth } from '../../lib/hooks/useAuth';
+import useOnboardingState from '../../lib/hooks/useOnboardingState';
+
+const TASKS_BY_ROLE: Record<string, { id: string; label: string; link: string }[]> = {
+  Admin: [
+    { id: 'setup_company', label: 'Set up Company Profile', link: '/settings' },
+    { id: 'add_team_member', label: 'Add Your First Team Member', link: '/admin/users' },
+    { id: 'define_services', label: 'Define Service Types', link: '/admin/catalog' },
+    { id: 'review_kpis', label: "Review Today's KPIs", link: '/admin/dashboard' },
+  ],
+  Sales: [
+    { id: 'add_lead', label: 'Add Your First Lead', link: '/crm/leads' },
+    { id: 'create_quote', label: 'Create Your First Quote', link: '/quotes' },
+    { id: 'explore_crm', label: 'Explore the CRM Pipeline', link: '/crm/leads' },
+  ],
+  Manager: [
+    { id: 'review_jobs', label: 'Review Jobs in Progress', link: '/install-manager/dashboard' },
+    { id: 'approve_quotes', label: 'Approve Pending Quotes', link: '/quotes' },
+    { id: 'payroll_report', label: 'Generate Payroll Report', link: '/reports' },
+  ],
+  Installer: [
+    { id: 'view_jobs', label: 'View Your Assigned Jobs', link: '/installer/dashboard' },
+    { id: 'complete_test_job', label: 'Complete First Job (Test)', link: '/installer/jobs/mock' },
+    { id: 'log_materials', label: 'Log Materials for a Job', link: '/installer/inventory' },
+  ],
+};
+
+interface Props {
+  role: string | null;
+  userId: string | null;
+}
+
+const OnboardingPanel: React.FC<Props> = ({ role, userId }) => {
+  const { user } = useAuth();
+  const { completedTasks, dismissed, completeTask, dismiss } = useOnboardingState(userId);
+
+  if (!role || !userId) return null;
+  const tasks = TASKS_BY_ROLE[role] || [];
+  const allDone = tasks.every((t) => completedTasks.includes(t.id));
+
+  if (dismissed || allDone || tasks.length === 0) return null;
+
+  const name = user?.full_name?.split(' ')[0] || 'User';
+  return (
+    <div className="p-4 mb-4 border rounded bg-yellow-50">
+      <div className="flex justify-between mb-2">
+        <div>
+          <h2 className="font-semibold">{`Welcome, ${name}! Let's get you set up as a ${role}.`}</h2>
+          <p className="text-sm text-gray-600">{`${completedTasks.length} of ${tasks.length} tasks completed`}</p>
+        </div>
+        <button onClick={dismiss} className="text-sm text-gray-500">Dismiss</button>
+      </div>
+      <ul className="space-y-1">
+        {tasks.map((task) => {
+          const done = completedTasks.includes(task.id);
+          return (
+            <li key={task.id} className="flex items-center">
+              <input
+                type="checkbox"
+                className="mr-2"
+                checked={done}
+                onChange={() => !done && completeTask(task.id)}
+              />
+              <a
+                href={task.link}
+                className={`hover:underline ${done ? 'line-through text-gray-600' : ''}`}
+              >
+                {task.label}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default OnboardingPanel;

--- a/installer-app/src/lib/hooks/useOnboardingState.ts
+++ b/installer-app/src/lib/hooks/useOnboardingState.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useState } from 'react';
+import supabase from '../supabaseClient';
+
+export default function useOnboardingState(userId: string | null) {
+  const [completedTasks, setCompletedTasks] = useState<string[]>([]);
+  const [dismissed, setDismissed] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!userId) return;
+    const { data } = await supabase
+      .from('user_settings')
+      .select('onboarding_completed_tasks,onboarding_dismissed_at')
+      .eq('user_id', userId)
+      .maybeSingle();
+    if (!data) {
+      await supabase.from('user_settings').insert({ user_id: userId });
+      setCompletedTasks([]);
+      setDismissed(false);
+    } else {
+      setCompletedTasks(data.onboarding_completed_tasks ?? []);
+      setDismissed(!!data.onboarding_dismissed_at);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const completeTask = useCallback(
+    async (taskId: string) => {
+      if (!userId) return;
+      const updated = Array.from(new Set([...completedTasks, taskId]));
+      setCompletedTasks(updated);
+      await supabase
+        .from('user_settings')
+        .update({ onboarding_completed_tasks: updated })
+        .eq('user_id', userId);
+    },
+    [userId, completedTasks],
+  );
+
+  const dismiss = useCallback(async () => {
+    if (!userId) return;
+    setDismissed(true);
+    await supabase
+      .from('user_settings')
+      .update({ onboarding_dismissed_at: new Date().toISOString() })
+      .eq('user_id', userId);
+  }, [userId]);
+
+  return { completedTasks, dismissed, completeTask, dismiss } as const;
+}

--- a/schema-lock.sql
+++ b/schema-lock.sql
@@ -116,3 +116,9 @@ CREATE TABLE public.users (
   active boolean NOT NULL,
   CONSTRAINT users_pkey PRIMARY KEY (id, active)
 );
+CREATE TABLE public.user_settings (
+  user_id uuid PRIMARY KEY REFERENCES auth.users(id),
+  onboarding_version integer DEFAULT 1,
+  onboarding_completed_tasks jsonb DEFAULT '[]',
+  onboarding_dismissed_at timestamp with time zone
+);


### PR DESCRIPTION
## Summary
- add `user_settings` table migration
- record onboarding progress with `useOnboardingState` hook
- implement `OnboardingPanel` component for role-based tasks
- show onboarding panel on Admin, Installer, Sales and Install Manager dashboards
- update schema reference

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685832cd6864832db38a7d24ee98cc80