### PR TITLE
Implement global search and filter components

### DIFF
--- a/installer-app/src/app/clients/ClientsPage.tsx
+++ b/installer-app/src/app/clients/ClientsPage.tsx
@@ -1,15 +1,50 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { SZButton } from "../../components/ui/SZButton";
 import { SZTable } from "../../components/ui/SZTable";
-import ClientFormModal, { Client } from "../../components/modals/ClientFormModal";
+import ClientFormModal, {
+  Client,
+} from "../../components/modals/ClientFormModal";
 import useClients from "../../lib/hooks/useClients";
-
+import SearchBar from "../../components/ui/search/SearchBar";
+import FilterPanel, {
+  AppliedFilters,
+  FilterDefinition,
+} from "../../components/ui/filters/FilterPanel";
+import ActiveFiltersDisplay from "../../components/ui/filters/ActiveFiltersDisplay";
+import { LoadingState, EmptyState } from "../../components/ui/state";
 
 const ClientsPage: React.FC = () => {
-  const [clients, { loading, error, createClient, updateClient, deleteClient }] =
-    useClients();
+  const [
+    clients,
+    { loading, error, createClient, updateClient, deleteClient },
+  ] = useClients();
   const [active, setActive] = useState<Client | null>(null);
   const [open, setOpen] = useState(false);
+
+  const [params, setParams] = useSearchParams();
+  const initialSearch = params.get("search") ?? "";
+  const [search, setSearch] = useState(initialSearch);
+
+  const initialFilters: AppliedFilters = {
+    status: params.get("status") ?? "",
+    created: { start: params.get("from") ?? "", end: params.get("to") ?? "" },
+  };
+  const [filters, setFilters] = useState<AppliedFilters>(initialFilters);
+
+  const filterDefs: FilterDefinition[] = [
+    {
+      key: "status",
+      label: "Status",
+      type: "dropdown",
+      options: [
+        { label: "All", value: "" },
+        { label: "active", value: "active" },
+        { label: "inactive", value: "inactive" },
+      ],
+    },
+    { key: "created", label: "Created Date", type: "dateRange" },
+  ];
 
   const handleSave = async (data: Client) => {
     try {
@@ -43,6 +78,81 @@ const ClientsPage: React.FC = () => {
     }
   };
 
+  const handleSearch = (term: string) => {
+    setSearch(term);
+    const p = new URLSearchParams(params);
+    if (term) {
+      p.set("search", term);
+    } else {
+      p.delete("search");
+    }
+    setParams(p);
+  };
+
+  const applyFilters = (vals: AppliedFilters) => {
+    setFilters(vals);
+    const p = new URLSearchParams(params);
+    if (vals.status) p.set("status", vals.status as string);
+    else p.delete("status");
+    if (vals.created?.start) p.set("from", vals.created.start);
+    else p.delete("from");
+    if (vals.created?.end) p.set("to", vals.created.end);
+    else p.delete("to");
+    setParams(p);
+  };
+
+  const removeFilter = (key: string) => {
+    const newFilters = { ...filters } as any;
+    delete newFilters[key];
+    setFilters(newFilters);
+    const p = new URLSearchParams(params);
+    if (key === "status") p.delete("status");
+    if (key === "created") {
+      p.delete("from");
+      p.delete("to");
+    }
+    if (key === "search") {
+      setSearch("");
+      p.delete("search");
+    }
+    setParams(p);
+  };
+
+  const clearAll = () => {
+    setFilters({ status: "", created: { start: "", end: "" } });
+    const p = new URLSearchParams(params);
+    ["search", "status", "from", "to"].forEach((k) => p.delete(k));
+    setParams(p);
+    setSearch("");
+  };
+
+  const filtered = useMemo(() => {
+    let list = clients;
+    if (search.trim()) {
+      const term = search.toLowerCase();
+      list = list.filter(
+        (c) =>
+          (c.name ?? "").toLowerCase().includes(term) ||
+          (c.contact_email ?? "").toLowerCase().includes(term) ||
+          (c.phone ?? "").toLowerCase().includes(term),
+      );
+    }
+    if (filters.status) {
+      list = list.filter((c) => c.status === filters.status);
+    }
+    if (filters.created?.start) {
+      list = list.filter(
+        (c) => c.created_at && c.created_at >= filters.created.start!,
+      );
+    }
+    if (filters.created?.end) {
+      list = list.filter(
+        (c) => c.created_at && c.created_at <= filters.created.end!,
+      );
+    }
+    return list;
+  }, [clients, search, filters]);
+
   return (
     <div className="p-4 space-y-4">
       <div className="flex justify-between items-center">
@@ -57,39 +167,78 @@ const ClientsPage: React.FC = () => {
           Add Client
         </SZButton>
       </div>
-      <div className="overflow-x-auto">
-        {loading && <p>Loading clients...</p>}
-        {error && <p className="text-red-600">Error: {error}</p>}
-        <SZTable headers={["Name", "Contact", "Email", "Address", "Actions"]}>
-          {clients.map((c) => (
-            <tr key={c.id} className="border-t">
-              <td className="p-2 border">{c.name}</td>
-              <td className="p-2 border">{c.contact_name}</td>
-              <td className="p-2 border">{c.contact_email}</td>
-              <td className="p-2 border">{c.address}</td>
-              <td className="p-2 border space-x-2">
-                <SZButton
-                  size="sm"
-                  variant="secondary"
-                  onClick={() => {
-                    setActive(c);
-                    setOpen(true);
-                  }}
-                >
-                  Edit
-                </SZButton>
-                <SZButton
-                  size="sm"
-                  variant="destructive"
-                  onClick={() => handleDelete(c.id!)}
-                >
-                  Delete
-                </SZButton>
-              </td>
-            </tr>
-          ))}
-        </SZTable>
+
+      <div className="flex flex-wrap items-end gap-4">
+        <div className="flex-1 min-w-[200px]">
+          <SearchBar
+            placeholder="Search clients"
+            onSearch={handleSearch}
+            initialValue={search}
+          />
+        </div>
+        <FilterPanel
+          filters={filterDefs}
+          onApply={applyFilters}
+          initialState={filters}
+        />
       </div>
+
+      <ActiveFiltersDisplay
+        filters={{ ...filters, ...(search ? { search } : {}) }}
+        onRemove={removeFilter}
+        onClearAll={clearAll}
+      />
+
+      <div className="overflow-x-auto">
+        {loading ? (
+          <LoadingState type="list" />
+        ) : error ? (
+          <p className="text-red-600">Error: {error}</p>
+        ) : filtered.length === 0 ? (
+          <EmptyState
+            title="No clients found"
+            description="Try adjusting your search or filters."
+          />
+        ) : (
+          <>
+            <p className="text-sm text-gray-600 mb-2">
+              Showing {filtered.length} of {clients.length} results
+            </p>
+            <SZTable
+              headers={["Name", "Contact", "Email", "Address", "Actions"]}
+            >
+              {filtered.map((c) => (
+                <tr key={c.id} className="border-t">
+                  <td className="p-2 border">{c.name}</td>
+                  <td className="p-2 border">{c.contact_name}</td>
+                  <td className="p-2 border">{c.contact_email}</td>
+                  <td className="p-2 border">{c.address}</td>
+                  <td className="p-2 border space-x-2">
+                    <SZButton
+                      size="sm"
+                      variant="secondary"
+                      onClick={() => {
+                        setActive(c);
+                        setOpen(true);
+                      }}
+                    >
+                      Edit
+                    </SZButton>
+                    <SZButton
+                      size="sm"
+                      variant="destructive"
+                      onClick={() => handleDelete(c.id!)}
+                    >
+                      Delete
+                    </SZButton>
+                  </td>
+                </tr>
+              ))}
+            </SZTable>
+          </>
+        )}
+      </div>
+
       <ClientFormModal
         isOpen={open}
         onClose={() => setOpen(false)}

--- a/installer-app/src/components/ui/filters/ActiveFiltersDisplay.tsx
+++ b/installer-app/src/components/ui/filters/ActiveFiltersDisplay.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { FaTimes } from "react-icons/fa";
+import { AppliedFilters } from "./FilterPanel";
+
+export interface ActiveFiltersDisplayProps {
+  filters: AppliedFilters;
+  onRemove: (key: string) => void;
+  onClearAll: () => void;
+}
+
+const formatValue = (val: any) => {
+  if (val == null || val === "") return "";
+  if (Array.isArray(val)) return val.join(", ");
+  if (typeof val === "object" && "start" in val && "end" in val) {
+    return `${val.start || "?"} - ${val.end || "?"}`;
+  }
+  if (typeof val === "boolean") return val ? "Yes" : "No";
+  return String(val);
+};
+
+export const ActiveFiltersDisplay: React.FC<ActiveFiltersDisplayProps> = ({
+  filters,
+  onRemove,
+  onClearAll,
+}) => {
+  const entries = Object.entries(filters).filter(([, v]) =>
+    Array.isArray(v) ? v.length > 0 : v !== undefined && v !== "",
+  );
+
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 mb-2">
+      {entries.map(([k, v]) => (
+        <span
+          key={k}
+          className="flex items-center bg-green-100 text-green-800 px-2 py-1 rounded-full text-sm"
+        >
+          {k}: {formatValue(v)}
+          <button className="ml-1" onClick={() => onRemove(k)}>
+            <FaTimes />
+          </button>
+        </span>
+      ))}
+      <button
+        className="text-sm text-gray-600 underline ml-2"
+        onClick={onClearAll}
+      >
+        Clear All
+      </button>
+    </div>
+  );
+};
+
+export default ActiveFiltersDisplay;

--- a/installer-app/src/components/ui/filters/DateRangeFilter.tsx
+++ b/installer-app/src/components/ui/filters/DateRangeFilter.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { SZInput } from "../SZInput";
+
+export interface DateRange {
+  start: string;
+  end: string;
+}
+
+export interface DateRangeFilterProps {
+  value: DateRange;
+  onChange: (value: DateRange) => void;
+}
+
+export const DateRangeFilter: React.FC<DateRangeFilterProps> = ({
+  value,
+  onChange,
+}) => {
+  return (
+    <div className="space-y-2">
+      <SZInput
+        id="start"
+        type="date"
+        label="From"
+        value={value.start}
+        onChange={(v) => onChange({ ...value, start: v })}
+      />
+      <SZInput
+        id="end"
+        type="date"
+        label="To"
+        value={value.end}
+        onChange={(v) => onChange({ ...value, end: v })}
+      />
+    </div>
+  );
+};
+
+export default DateRangeFilter;

--- a/installer-app/src/components/ui/filters/FilterPanel.tsx
+++ b/installer-app/src/components/ui/filters/FilterPanel.tsx
@@ -1,0 +1,191 @@
+import React, { useEffect, useState } from "react";
+import ModalWrapper from "../../installer/components/ModalWrapper";
+import { SZButton } from "../SZButton";
+import { SZCheckbox } from "../SZCheckbox";
+import MultiCheckboxFilter, { Option as MCOption } from "./MultiCheckboxFilter";
+import DateRangeFilter, { DateRange } from "./DateRangeFilter";
+
+export type AppliedFilters = Record<string, any>;
+
+interface BaseFilterDef {
+  key: string;
+  label: string;
+}
+
+export interface DropdownFilter extends BaseFilterDef {
+  type: "dropdown";
+  options: MCOption[];
+}
+
+export interface MultiSelectFilter extends BaseFilterDef {
+  type: "multi";
+  options: MCOption[];
+}
+
+export interface DateRangeFilterDef extends BaseFilterDef {
+  type: "dateRange";
+}
+
+export interface BooleanFilterDef extends BaseFilterDef {
+  type: "boolean";
+}
+
+export interface NumericRangeFilterDef extends BaseFilterDef {
+  type: "numericRange";
+  minLabel?: string;
+  maxLabel?: string;
+}
+
+export type FilterDefinition =
+  | DropdownFilter
+  | MultiSelectFilter
+  | DateRangeFilterDef
+  | BooleanFilterDef
+  | NumericRangeFilterDef;
+
+export interface FilterPanelProps {
+  filters: FilterDefinition[];
+  onApply: (filters: AppliedFilters) => void;
+  initialState?: AppliedFilters;
+}
+
+export const FilterPanel: React.FC<FilterPanelProps> = ({
+  filters,
+  onApply,
+  initialState = {},
+}) => {
+  const [values, setValues] = useState<AppliedFilters>(initialState);
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  useEffect(() => {
+    setValues(initialState);
+  }, [initialState]);
+
+  const update = (key: string, val: any) => {
+    setValues((v) => ({ ...v, [key]: val }));
+  };
+
+  const content = (
+    <div className="space-y-4 p-4">
+      {filters.map((f) => {
+        const val = values[f.key];
+        switch (f.type) {
+          case "dropdown":
+            return (
+              <div key={f.key}>
+                <label
+                  className="block text-sm font-medium text-gray-700"
+                  htmlFor={f.key}
+                >
+                  {f.label}
+                </label>
+                <select
+                  id={f.key}
+                  className="mt-1 w-full border rounded px-3 py-2"
+                  value={val ?? ""}
+                  onChange={(e) => update(f.key, e.target.value)}
+                >
+                  {f.options.map((o) => (
+                    <option key={o.value} value={o.value}>
+                      {o.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            );
+          case "multi":
+            return (
+              <div key={f.key}>
+                <p className="text-sm font-medium text-gray-700">{f.label}</p>
+                <MultiCheckboxFilter
+                  options={f.options}
+                  values={val ?? []}
+                  onChange={(v) => update(f.key, v)}
+                />
+              </div>
+            );
+          case "dateRange":
+            return (
+              <div key={f.key}>
+                <p className="text-sm font-medium text-gray-700 mb-1">
+                  {f.label}
+                </p>
+                <DateRangeFilter
+                  value={val ?? { start: "", end: "" }}
+                  onChange={(v: DateRange) => update(f.key, v)}
+                />
+              </div>
+            );
+          case "boolean":
+            return (
+              <SZCheckbox
+                key={f.key}
+                id={f.key}
+                label={f.label}
+                checked={!!val}
+                onChange={(v) => update(f.key, v)}
+              />
+            );
+          case "numericRange":
+            return (
+              <div key={f.key} className="space-y-2">
+                <label className="block text-sm font-medium text-gray-700">
+                  {f.label}
+                </label>
+                <input
+                  type="number"
+                  placeholder={f.minLabel ?? "Min"}
+                  className="w-full border rounded px-3 py-2"
+                  value={val?.min ?? ""}
+                  onChange={(e) =>
+                    update(f.key, { ...val, min: e.target.value })
+                  }
+                />
+                <input
+                  type="number"
+                  placeholder={f.maxLabel ?? "Max"}
+                  className="w-full border rounded px-3 py-2"
+                  value={val?.max ?? ""}
+                  onChange={(e) =>
+                    update(f.key, { ...val, max: e.target.value })
+                  }
+                />
+              </div>
+            );
+          default:
+            return null;
+        }
+      })}
+      <div className="flex justify-end gap-2">
+        <SZButton
+          variant="secondary"
+          onClick={() => {
+            setValues(initialState);
+            onApply(initialState);
+          }}
+        >
+          Clear
+        </SZButton>
+        <SZButton onClick={() => onApply(values)}>Apply</SZButton>
+      </div>
+    </div>
+  );
+
+  return (
+    <div>
+      <div className="hidden sm:block border rounded-md bg-white w-64">
+        {content}
+      </div>
+      <div className="sm:hidden">
+        <SZButton variant="secondary" onClick={() => setMobileOpen(true)}>
+          Filters
+        </SZButton>
+        <ModalWrapper isOpen={mobileOpen} onClose={() => setMobileOpen(false)}>
+          {content}
+        </ModalWrapper>
+      </div>
+    </div>
+  );
+};
+
+export default FilterPanel;

--- a/installer-app/src/components/ui/filters/MultiCheckboxFilter.tsx
+++ b/installer-app/src/components/ui/filters/MultiCheckboxFilter.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { SZCheckbox } from "../SZCheckbox";
+
+export interface Option {
+  label: string;
+  value: string;
+}
+
+export interface MultiCheckboxFilterProps {
+  options: Option[];
+  values: string[];
+  onChange: (values: string[]) => void;
+}
+
+export const MultiCheckboxFilter: React.FC<MultiCheckboxFilterProps> = ({
+  options,
+  values,
+  onChange,
+}) => {
+  const toggle = (val: string, checked: boolean) => {
+    if (checked) {
+      onChange([...values, val]);
+    } else {
+      onChange(values.filter((v) => v !== val));
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      {options.map((o) => (
+        <SZCheckbox
+          key={o.value}
+          id={o.value}
+          label={o.label}
+          checked={values.includes(o.value)}
+          onChange={(c) => toggle(o.value, c)}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default MultiCheckboxFilter;

--- a/installer-app/src/components/ui/search/SearchBar.tsx
+++ b/installer-app/src/components/ui/search/SearchBar.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from "react";
+import { FaTimes } from "react-icons/fa";
+
+export type SearchBarProps = {
+  placeholder?: string;
+  onSearch: (term: string) => void;
+  initialValue?: string;
+};
+
+export const SearchBar: React.FC<SearchBarProps> = ({
+  placeholder = "Search...",
+  onSearch,
+  initialValue = "",
+}) => {
+  const [term, setTerm] = useState(initialValue);
+
+  useEffect(() => {
+    setTerm(initialValue);
+  }, [initialValue]);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      onSearch(term.trim());
+    }, 300);
+    return () => clearTimeout(handler);
+  }, [term, onSearch]);
+
+  return (
+    <div className="relative">
+      <input
+        type="text"
+        placeholder={placeholder}
+        value={term}
+        onChange={(e) => setTerm(e.target.value)}
+        className="w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-500"
+      />
+      {term && (
+        <button
+          aria-label="Clear search"
+          onClick={() => setTerm("")}
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400"
+        >
+          <FaTimes />
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default SearchBar;

--- a/installer-app/src/lib/hooks/useClients.ts
+++ b/installer-app/src/lib/hooks/useClients.ts
@@ -7,6 +7,9 @@ export interface Client {
   contact_name: string;
   contact_email: string;
   address: string;
+  phone?: string;
+  status?: string;
+  created_at?: string;
 }
 
 export function useClients() {
@@ -18,7 +21,9 @@ export function useClients() {
     setLoading(true);
     const { data, error } = await supabase
       .from<Client>("clients")
-      .select("id, name, contact_name, contact_email, address")
+      .select(
+        "id, name, contact_name, contact_email, address, phone, status, created_at",
+      )
       .order("name", { ascending: true });
     if (error) {
       setError(error.message);
@@ -41,17 +46,20 @@ export function useClients() {
     return data;
   }, []);
 
-  const updateClient = useCallback(async (id: string, client: Omit<Client, "id">) => {
-    const { data, error } = await supabase
-      .from<Client>("clients")
-      .update(client)
-      .eq("id", id)
-      .select()
-      .single();
-    if (error) throw error;
-    setClients((cs) => cs.map((c) => (c.id === id ? data : c)));
-    return data;
-  }, []);
+  const updateClient = useCallback(
+    async (id: string, client: Omit<Client, "id">) => {
+      const { data, error } = await supabase
+        .from<Client>("clients")
+        .update(client)
+        .eq("id", id)
+        .select()
+        .single();
+      if (error) throw error;
+      setClients((cs) => cs.map((c) => (c.id === id ? data : c)));
+      return data;
+    },
+    [],
+  );
 
   const deleteClient = useCallback(async (id: string) => {
     const { error } = await supabase.from("clients").delete().eq("id", id);


### PR DESCRIPTION
## Summary
- add reusable `SearchBar` with debounce
- add modular filter system with multi-select and date range components
- show active filters with ability to clear
- extend `useClients` hook with phone, status and created_at fields
- integrate search and filters into `ClientsPage`

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68583208e884832d88af3b4d3f740710