### PR TITLE
Add Technician Pay report page

### DIFF
--- a/installer-app/src/App.jsx
+++ b/installer-app/src/App.jsx
@@ -36,6 +36,7 @@ const PaymentsPage = lazy(() => import("./app/payments/PaymentsPage"));
 const MessagesPanel = lazy(() => import("./app/messages/MessagesPanel"));
 const TimeTrackingPanel = lazy(() => import("./app/time-tracking/TimeTrackingPanel"));
 const ReportsPage = lazy(() => import("./app/reports/ReportsPage"));
+const TechnicianPayReportPage = lazy(() => import("./app/reports/TechnicianPayReportPage"));
 const LeadsPage = lazy(() => import("./app/crm/LeadsPage"));
 
 const App = () => {
@@ -93,6 +94,7 @@ const App = () => {
                 <Route path="/messages" element={<RequireRole role={["Manager", "Admin"]}><MessagesPanel /></RequireRole>} />
                 <Route path="/time-tracking" element={<RequireRole role={["Manager", "Admin"]}><TimeTrackingPanel /></RequireRole>} />
                 <Route path="/reports" element={<RequireRole role={["Manager", "Admin"]}><ReportsPage /></RequireRole>} />
+                <Route path="/reports/technician-pay" element={<RequireRole role={["Admin", "Install Manager"]}><TechnicianPayReportPage /></RequireRole>} />
 
                 {/* Fallback for authenticated routes */}
                 <Route path="*" element={<Navigate to="/" replace />} />

--- a/installer-app/src/app/reports/TechnicianPayReportPage.tsx
+++ b/installer-app/src/app/reports/TechnicianPayReportPage.tsx
@@ -1,0 +1,212 @@
+import React, { useMemo, useState } from "react";
+import { DateRangeFilter } from "../../components/ui/filters/DateRangeFilter";
+import { SZButton } from "../../components/ui/SZButton";
+import { SZTable } from "../../components/ui/SZTable";
+import {
+  LoadingState,
+  EmptyState,
+  ErrorState,
+} from "../../components/ui/state";
+import useTechnicianPayReport, {
+  PayLine,
+} from "../../lib/hooks/useTechnicianPayReport";
+import { useInstallers } from "../../lib/hooks/useInstallers";
+
+function csvEscape(value: string | number | null) {
+  if (value === null || value === undefined) return "";
+  const str = String(value);
+  return `"${str.replace(/"/g, '""')}"`;
+}
+
+const TechnicianPayReportPage: React.FC = () => {
+  const today = new Date().toISOString().slice(0, 10);
+  const past = new Date();
+  past.setDate(past.getDate() - 30);
+  const [range, setRange] = useState({
+    start: past.toISOString().slice(0, 10),
+    end: today,
+  });
+  const [tech, setTech] = useState("");
+  const { installers } = useInstallers();
+  const { lines, loading, error } = useTechnicianPayReport(
+    range.start,
+    range.end,
+    tech || undefined,
+  );
+
+  const grouped = useMemo(() => {
+    const result: Record<
+      string,
+      {
+        name: string;
+        jobs: Record<
+          string,
+          {
+            name: string;
+            client: string | null;
+            date: string | null;
+            lines: PayLine[];
+            total: number;
+          }
+        >;
+        total: number;
+      }
+    > = {};
+    lines.forEach((l) => {
+      const techEntry = result[l.user_id] || {
+        name: l.user_name ?? l.user_id,
+        jobs: {},
+        total: 0,
+      };
+      result[l.user_id] = techEntry;
+      const job = techEntry.jobs[l.job_id] || {
+        name: l.job_name ?? l.job_id,
+        client: l.client_name,
+        date: l.completed_at,
+        lines: [],
+        total: 0,
+      };
+      techEntry.jobs[l.job_id] = job;
+      job.lines.push(l);
+      job.total += l.subtotal;
+      techEntry.total += l.subtotal;
+    });
+    return result;
+  }, [lines]);
+
+  const summary = useMemo(() => {
+    let pay = 0;
+    let jobs = 0;
+    Object.values(grouped).forEach((t) => {
+      pay += t.total;
+      jobs += Object.keys(t.jobs).length;
+    });
+    return { pay, jobs, techs: Object.keys(grouped).length };
+  }, [grouped]);
+
+  const exportCSV = () => {
+    let csv =
+      "Technician,Job,Client,Completed,Material,Quantity,Rate,Subtotal\n";
+    lines.forEach((l) => {
+      csv +=
+        [
+          csvEscape(l.user_name),
+          csvEscape(l.job_name),
+          csvEscape(l.client_name),
+          csvEscape(
+            l.completed_at ? new Date(l.completed_at).toLocaleDateString() : "",
+          ),
+          csvEscape(l.material_name),
+          l.quantity,
+          l.rate,
+          l.subtotal,
+        ].join(",") + "\n";
+    });
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "technician_pay.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Technician Pay Report</h1>
+      <div className="flex flex-wrap gap-4 items-end">
+        <DateRangeFilter value={range} onChange={setRange} />
+        <div>
+          <label
+            className="block text-sm font-medium text-gray-700"
+            htmlFor="tech"
+          >
+            Technician
+          </label>
+          <select
+            id="tech"
+            className="border rounded px-2 py-1"
+            value={tech}
+            onChange={(e) => setTech(e.target.value)}
+          >
+            <option value="">All</option>
+            {installers.map((i) => (
+              <option key={i.id} value={i.id}>
+                {i.full_name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <SZButton size="sm" onClick={exportCSV}>
+          Export CSV
+        </SZButton>
+        <SZButton size="sm" variant="secondary" onClick={() => window.print()}>
+          PDF / Print
+        </SZButton>
+      </div>
+      <div className="bg-gray-50 p-3 rounded">
+        <p>Total Pay: ${summary.pay.toFixed(2)}</p>
+        <p>Total Jobs: {summary.jobs}</p>
+        <p>Installers: {summary.techs}</p>
+      </div>
+      {loading && <LoadingState type="list" />}
+      {error && <ErrorState message={error} />}
+      {!loading && !error && lines.length === 0 && (
+        <EmptyState
+          title="No Results"
+          description="No pay records found for the selected period."
+        />
+      )}
+      {!loading &&
+        !error &&
+        Object.keys(grouped).map((tid) => {
+          const tech = grouped[tid];
+          return (
+            <div key={tid} className="space-y-2">
+              <h2 className="text-xl font-semibold mt-4">{tech.name}</h2>
+              {Object.keys(tech.jobs).map((jid) => {
+                const job = tech.jobs[jid];
+                return (
+                  <div key={jid} className="mb-4 overflow-x-auto">
+                    <h3 className="font-semibold mb-1">
+                      {job.name} - {job.client || ""} -{" "}
+                      {job.date ? new Date(job.date).toLocaleDateString() : ""}
+                    </h3>
+                    <SZTable headers={["Material", "Qty", "Rate", "Subtotal"]}>
+                      {job.lines.map((line, idx) => (
+                        <tr key={idx} className="border-t">
+                          <td className="p-2 border">{line.material_name}</td>
+                          <td className="p-2 border text-right">
+                            {line.quantity}
+                          </td>
+                          <td className="p-2 border text-right">
+                            ${line.rate.toFixed(2)}
+                          </td>
+                          <td className="p-2 border text-right">
+                            ${line.subtotal.toFixed(2)}
+                          </td>
+                        </tr>
+                      ))}
+                      <tr className="border-t font-semibold">
+                        <td className="p-2 border" colSpan={3}>
+                          Job Total
+                        </td>
+                        <td className="p-2 border text-right">
+                          ${job.total.toFixed(2)}
+                        </td>
+                      </tr>
+                    </SZTable>
+                  </div>
+                );
+              })}
+              <div className="font-bold">
+                Technician Total: ${tech.total.toFixed(2)}
+              </div>
+            </div>
+          );
+        })}
+    </div>
+  );
+};
+
+export default TechnicianPayReportPage;

--- a/installer-app/src/components/layout/Sidebar.tsx
+++ b/installer-app/src/components/layout/Sidebar.tsx
@@ -22,6 +22,7 @@ const adminLinks: LinkItem[] = [
   { to: "/invoices", label: "Invoices" },
   { to: "/payments", label: "Payments" },
   { to: "/reports", label: "Reports" },
+  { to: "/reports/technician-pay", label: "Technician Pay" },
   { to: "/settings", label: "Settings" },
 ];
 
@@ -34,6 +35,7 @@ const managerLinks: LinkItem[] = [
   { to: "/invoices", label: "Invoices" },
   { to: "/payments", label: "Payments" },
   { to: "/reports", label: "Reports" },
+  { to: "/reports/technician-pay", label: "Technician Pay" },
   { to: "/settings", label: "Settings" },
 ];
 

--- a/installer-app/src/components/navigation/Sidebar.tsx
+++ b/installer-app/src/components/navigation/Sidebar.tsx
@@ -17,6 +17,7 @@ const menu = {
     { label: "Invoices", path: "/invoices" },
     { label: "Payments", path: "/payments" },
     { label: "Reports", path: "/reports" },
+    { label: "Technician Pay", path: "/reports/technician-pay" },
     { label: "Settings", path: "/settings" },
   ],
   Manager: [
@@ -28,6 +29,7 @@ const menu = {
     { label: "Invoices", path: "/invoices" },
     { label: "Payments", path: "/payments" },
     { label: "Reports", path: "/reports" },
+    { label: "Technician Pay", path: "/reports/technician-pay" },
     { label: "Settings", path: "/settings" },
   ],
   Sales: [

--- a/installer-app/src/components/onboarding/OnboardingPanel.tsx
+++ b/installer-app/src/components/onboarding/OnboardingPanel.tsx
@@ -17,7 +17,7 @@ const TASKS_BY_ROLE: Record<string, { id: string; label: string; link: string }[
   Manager: [
     { id: 'review_jobs', label: 'Review Jobs in Progress', link: '/install-manager/dashboard' },
     { id: 'approve_quotes', label: 'Approve Pending Quotes', link: '/quotes' },
-    { id: 'payroll_report', label: 'Generate Payroll Report', link: '/reports' },
+    { id: 'payroll_report', label: 'Generate Payroll Report', link: '/reports/technician-pay' },
   ],
   Installer: [
     { id: 'view_jobs', label: 'View Your Assigned Jobs', link: '/installer/dashboard' },

--- a/installer-app/src/lib/hooks/useTechnicianPayReport.ts
+++ b/installer-app/src/lib/hooks/useTechnicianPayReport.ts
@@ -1,0 +1,72 @@
+export interface PayLine {
+  user_id: string;
+  user_name: string | null;
+  job_id: string;
+  job_name: string | null;
+  client_name: string | null;
+  completed_at: string | null;
+  material_name: string | null;
+  rate: number;
+  quantity: number;
+  subtotal: number;
+}
+
+import { useEffect, useState } from "react";
+import supabase from "../supabaseClient";
+
+export default function useTechnicianPayReport(
+  start?: string,
+  end?: string,
+  technicianId?: string,
+) {
+  const [lines, setLines] = useState<PayLine[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      let query = supabase.from("job_quantities_completed").select(`
+          quantity_completed,
+          user_id,
+          job_id,
+          jobs(name, completed_at, client_id, clients(name)),
+          materials(name, default_pay_rate),
+          users(full_name)
+        `);
+
+      if (start) query = query.gte("jobs.completed_at", start);
+      if (end) query = query.lte("jobs.completed_at", end);
+      if (technicianId) query = query.eq("user_id", technicianId);
+
+      const { data, error } = await query;
+      if (error) {
+        setError(error.message);
+        setLines([]);
+      } else {
+        const mapped = (data ?? []).map((row: any) => {
+          const rate = row.materials?.default_pay_rate ?? 0;
+          const qty = row.quantity_completed ?? 0;
+          return {
+            user_id: row.user_id,
+            user_name: row.users?.full_name ?? null,
+            job_id: row.job_id,
+            job_name: row.jobs?.name ?? null,
+            client_name: row.jobs?.clients?.name ?? null,
+            completed_at: row.jobs?.completed_at ?? null,
+            material_name: row.materials?.name ?? null,
+            rate,
+            quantity: qty,
+            subtotal: qty * rate,
+          } as PayLine;
+        });
+        setLines(mapped);
+        setError(null);
+      }
+      setLoading(false);
+    };
+    load();
+  }, [start, end, technicianId]);
+
+  return { lines, loading, error } as const;
+}

--- a/installer-app/src/navConfig.js
+++ b/installer-app/src/navConfig.js
@@ -17,5 +17,6 @@ export const navLinks = [
   { path: '/messages', label: 'Messages', roles: ['Admin', 'Manager'] },
   { path: '/time-tracking', label: 'Time Tracking', roles: ['Admin', 'Manager'] },
   { path: '/reports', label: 'Reports', roles: ['Admin', 'Manager'] },
+  { path: '/reports/technician-pay', label: 'Technician Pay', roles: ['Admin', 'Install Manager'] },
   { path: '#', label: 'MyLearning - SentientZone', roles: ['Installer'] },
 ];


### PR DESCRIPTION
## Summary
- create `useTechnicianPayReport` hook
- add `TechnicianPayReportPage` with filters and export
- expose new page in navigation and onboarding
- restrict route to Admin or Install Manager

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685837a02d24832d956c81a570554d14