### PR TITLE
Fix Supabase dashboard queries

### DIFF
--- a/installer-app/src/app/install-manager/QAReviewPanel.tsx
+++ b/installer-app/src/app/install-manager/QAReviewPanel.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useCallback } from "react";
 import JobCard from "../../components/JobCard";
 import { SZButton } from "../../components/ui/SZButton";
 import supabase from "../../lib/supabaseClient";
+import { getJobsNeedingQA } from "../../features/jobs/jobService";
 import DocumentViewerModal from "../../installer/components/DocumentViewerModal";
 
 export type QAReviewPanelProps = {};
@@ -33,25 +34,23 @@ const QAReviewPanel: React.FC<QAReviewPanelProps> = () => {
   const fetchJobs = useCallback(async () => {
     setLoading(true);
     setError(null);
-    const { data, error } = await supabase
-      .from<QAJobRow>("jobs")
-      .select(
-        "id, address, assigned_to, status, scheduled_date, documents(id, name, url, path, type)",
-      )
-      .eq("status", "needs_qa");
-    if (error) {
-      setError(error.message);
+    try {
+      const data = await getJobsNeedingQA();
+      setJobs(
+        data.map((j) => ({
+          id: j.id,
+          address: j.address,
+          assignedTo: j.assigned_to,
+          status: j.status,
+          scheduledDate: j.scheduled_date,
+          documents: j.documents ?? [],
+        }))
+      );
+    } catch (err: any) {
+      console.error("Error loading QA jobs", err);
+      setError(err.message);
+      setJobs([]);
     }
-    setJobs(
-      (data ?? []).map((j) => ({
-        id: j.id,
-        address: j.address,
-        assignedTo: j.assigned_to,
-        status: j.status,
-        scheduledDate: j.scheduled_date,
-        documents: j.documents ?? [],
-      })),
-    );
     setLoading(false);
   }, []);
 

--- a/installer-app/src/features/jobs/jobService.ts
+++ b/installer-app/src/features/jobs/jobService.ts
@@ -44,3 +44,26 @@ export async function getJobById(id: string): Promise<JobDetail | null> {
     documents: data.documents || [],
   } as JobDetail;
 }
+
+export interface QAJobListItem {
+  id: string;
+  address: string;
+  assigned_to: string | null;
+  status: string;
+  scheduled_date: string;
+  documents: any[] | null;
+}
+
+export async function getJobsNeedingQA(): Promise<QAJobListItem[]> {
+  const { data, error } = await supabase
+    .from<QAJobListItem>("jobs")
+    .select(
+      "id, address, assigned_to, status, scheduled_date, documents(id, name, url, path, type)"
+    )
+    .eq("status", "needs_qa");
+  if (error) {
+    console.error("Failed to fetch QA jobs", error);
+    throw error;
+  }
+  return data ?? [];
+}

--- a/installer-app/src/lib/hooks/useInstallers.ts
+++ b/installer-app/src/lib/hooks/useInstallers.ts
@@ -14,16 +14,17 @@ export function useInstallers() {
   const fetchInstallers = useCallback(async () => {
     setLoading(true);
     const { data, error } = await supabase
-      .from("user_roles")
-      .select("user_id, users(full_name)")
+      .from("users")
+      .select("id, full_name")
       .eq("role", "Installer");
     if (error) {
+      console.error("Failed to load installers", error);
       setError(error.message);
       setInstallers([]);
     } else {
       const mapped = (data ?? []).map((row: any) => ({
-        id: row.user_id,
-        full_name: row.users?.full_name ?? null,
+        id: row.id,
+        full_name: row.full_name ?? null,
       }));
       setInstallers(mapped);
       setError(null);


### PR DESCRIPTION
## Summary
- fetch installers from `users` table and log load errors
- expose a `getJobsNeedingQA` helper
- use helper in Install Manager QA panel with error logging

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68587ee86c44832da212207a178142ee