### PR TITLE
Add admin user role editor

### DIFF
--- a/installer-app/src/app/admin/users/AdminUserForm.tsx
+++ b/installer-app/src/app/admin/users/AdminUserForm.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from "react";
+import ModalWrapper from "../../../installer/components/ModalWrapper";
+import { SZButton } from "../../../components/ui/SZButton";
+import { SZInput } from "../../../components/ui/SZInput";
+import supabase from "../../../lib/supabaseClient";
+import { AdminUser } from "./AdminUserListPage";
+import UserRoleEditor from "./UserRoleEditor";
+
+type Props = {
+  user: AdminUser;
+  onClose: () => void;
+};
+
+const AdminUserForm: React.FC<Props> = ({ user, onClose }) => {
+  const [form, setForm] = useState<AdminUser>({
+    id: user.id,
+    email: user.email || "",
+    full_name: user.full_name || "",
+    active: user.active ?? true,
+  });
+
+  const save = async () => {
+    if (form.id) {
+      await supabase
+        .from("users")
+        .update({
+          email: form.email,
+          full_name: form.full_name,
+          active: form.active,
+        })
+        .eq("id", form.id);
+    } else {
+      await supabase.from("users").insert({
+        email: form.email,
+        full_name: form.full_name,
+        active: form.active,
+      });
+    }
+    onClose();
+  };
+
+  return (
+    <ModalWrapper isOpen={true} onClose={onClose}>
+      <h2 className="text-lg font-semibold mb-4">
+        {form.id ? "Edit User" : "New User"}
+      </h2>
+      <div className="space-y-2">
+        <SZInput
+          id="user_email"
+          label="Email"
+          value={form.email}
+          onChange={(v) => setForm((f) => ({ ...f, email: v }))}
+        />
+        <SZInput
+          id="user_fullname"
+          label="Full Name"
+          value={form.full_name ?? ""}
+          onChange={(v) => setForm((f) => ({ ...f, full_name: v }))}
+        />
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={form.active ?? true}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, active: e.target.checked }))
+            }
+          />
+          Active
+        </label>
+        {form.id && <UserRoleEditor userId={form.id} />}
+      </div>
+      <div className="mt-4 flex justify-end gap-2">
+        <SZButton variant="secondary" onClick={onClose}>
+          Cancel
+        </SZButton>
+        <SZButton onClick={save}>Save</SZButton>
+      </div>
+    </ModalWrapper>
+  );
+};
+
+export default AdminUserForm;

--- a/installer-app/src/app/admin/users/AdminUserListPage.tsx
+++ b/installer-app/src/app/admin/users/AdminUserListPage.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from "react";
+import { SZCard } from "../../../components/ui/SZCard";
+import { SZButton } from "../../../components/ui/SZButton";
+import supabase from "../../../lib/supabaseClient";
+import AdminUserForm from "./AdminUserForm";
+
+export interface AdminUser {
+  id?: string;
+  email: string;
+  full_name?: string | null;
+  active?: boolean | null;
+  created_at?: string;
+}
+
+const AdminUserListPage: React.FC = () => {
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [selected, setSelected] = useState<AdminUser | null>(null);
+
+  const fetchUsers = async () => {
+    const { data } = await supabase
+      .from<AdminUser>("users")
+      .select("id, email, full_name, active, created_at");
+    setUsers(data ?? []);
+  };
+
+  useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">User Management</h1>
+      <SZButton
+        size="sm"
+        onClick={() => setSelected({ email: "", full_name: "", active: true })}
+      >
+        New User
+      </SZButton>
+      {users.map((u) => (
+        <SZCard key={u.id}>
+          <div className="flex justify-between items-center">
+            <div>
+              <p>
+                {u.full_name || "(No Name)"} ({u.email})
+              </p>
+              <p className="text-sm text-gray-500">
+                {u.active ? "Active" : "Deactivated"}
+              </p>
+            </div>
+            <SZButton size="sm" onClick={() => setSelected(u)}>
+              Edit
+            </SZButton>
+          </div>
+        </SZCard>
+      ))}
+      {selected && (
+        <AdminUserForm
+          user={selected}
+          onClose={() => {
+            setSelected(null);
+            fetchUsers();
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default AdminUserListPage;

--- a/installer-app/src/app/admin/users/UserRoleEditor.tsx
+++ b/installer-app/src/app/admin/users/UserRoleEditor.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { SZButton } from "../../../components/ui/SZButton";
+import supabase from "../../../lib/supabaseClient";
+
+const ALL_ROLES = ["Admin", "Manager", "Installer", "Sales", "Finance"];
+
+export default function UserRoleEditor({ userId }: { userId: string }) {
+  const [role, setRole] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetch = async () => {
+      const { data } = await supabase
+        .from("users")
+        .select("role")
+        .eq("id", userId)
+        .single();
+      setRole(data?.role ?? null);
+    };
+    fetch();
+  }, [userId]);
+
+  const updateRole = async (newRole: string) => {
+    await supabase.from("users").update({ role: newRole }).eq("id", userId);
+    setRole(newRole);
+  };
+
+  return (
+    <div className="space-y-1">
+      <h3 className="font-semibold">Role</h3>
+      <div className="flex flex-wrap gap-2">
+        {ALL_ROLES.map((r) => (
+          <SZButton
+            key={r}
+            onClick={() => updateRole(r)}
+            variant={role === r ? "primary" : "secondary"}
+            size="sm"
+          >
+            {r}
+          </SZButton>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/installer-app/src/routes.ts
+++ b/installer-app/src/routes.ts
@@ -10,6 +10,7 @@ import MockJobsPage from "./installer/pages/MockJobsPage";
 import FeedbackPage from "./installer/pages/FeedbackPage";
 import InstallManagerDashboard from "./app/install-manager/page.jsx";
 import AdminDashboard from "./app/admin/AdminDashboard";
+import AdminUserListPage from "./app/admin/users/AdminUserListPage";
 import SalesDashboard from "./app/sales/SalesDashboard";
 import NewJobBuilderPage from "./app/install-manager/job/NewJobBuilderPage";
 import AdminNewJob from "./app/admin/jobs/AdminNewJob";
@@ -125,6 +126,12 @@ export const ROUTES: RouteConfig[] = [
     element: React.createElement(AdminDashboard),
     role: "Admin",
     label: "Admin Dashboard",
+  },
+  {
+    path: "/admin/users",
+    element: React.createElement(AdminUserListPage),
+    role: "Admin",
+    label: "User Management",
   },
   {
     path: "/admin/jobs/new",


### PR DESCRIPTION
## Summary
- add `UserRoleEditor` component for managing user roles
- show role editor in `AdminUserForm` when editing existing user

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858928b6f34832dbdf390e030c3281d