### PR TITLE
Add invite user page

### DIFF
--- a/installer-app/api/migrations/029_create_pending_user_function.sql
+++ b/installer-app/api/migrations/029_create_pending_user_function.sql
@@ -1,0 +1,8 @@
+create or replace function create_pending_user(email text, role text)
+returns void as $$
+begin
+  insert into public.users (email, role, status)
+  values (email, role, 'pending')
+  on conflict (email) do nothing;
+end;
+$$ language plpgsql;

--- a/installer-app/src/app/admin/users/AdminInviteUserPage.tsx
+++ b/installer-app/src/app/admin/users/AdminInviteUserPage.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from "react";
+import { SZInput } from "../../../components/ui/SZInput";
+import { SZButton } from "../../../components/ui/SZButton";
+import supabase from "../../../lib/supabaseClient";
+
+const ROLES = ["Admin", "Installer", "Sales", "Manager"];
+
+type Toast = { message: string; success: boolean } | null;
+
+const AdminInviteUserPage: React.FC = () => {
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState("Installer");
+  const [loading, setLoading] = useState(false);
+  const [toast, setToast] = useState<Toast>(null);
+
+  const submitInvite = async () => {
+    setLoading(true);
+    setToast(null);
+    const { error } = await supabase.rpc("create_pending_user", {
+      email,
+      role,
+    });
+    if (error) {
+      setToast({ message: error.message, success: false });
+    } else {
+      setToast({ message: `Invite sent to ${email}`, success: true });
+      setEmail("");
+      setRole("Installer");
+    }
+    setLoading(false);
+    setTimeout(() => setToast(null), 3000);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Invite User</h1>
+      <SZInput id="invite_email" label="Email" value={email} onChange={setEmail} />
+      <div className="space-y-1">
+        <label htmlFor="invite_role" className="block text-sm font-medium text-gray-700">
+          Role
+        </label>
+        <select
+          id="invite_role"
+          value={role}
+          onChange={(e) => setRole(e.target.value)}
+          className="border rounded px-3 py-2 w-full"
+        >
+          {ROLES.map((r) => (
+            <option key={r} value={r}>
+              {r}
+            </option>
+          ))}
+        </select>
+      </div>
+      {toast && (
+        <div
+          className={`fixed top-4 right-4 text-white px-4 py-2 rounded ${toast.success ? "bg-green-600" : "bg-red-600"}`}
+        >
+          {toast.message}
+        </div>
+      )}
+      <SZButton onClick={submitInvite} isLoading={loading}>
+        Invite User
+      </SZButton>
+    </div>
+  );
+};
+
+export default AdminInviteUserPage;

--- a/installer-app/src/routes.ts
+++ b/installer-app/src/routes.ts
@@ -11,6 +11,7 @@ import FeedbackPage from "./installer/pages/FeedbackPage";
 import InstallManagerDashboard from "./app/install-manager/page.jsx";
 import AdminDashboard from "./app/admin/AdminDashboard";
 import AdminUserListPage from "./app/admin/users/AdminUserListPage";
+import AdminInviteUserPage from "./app/admin/users/AdminInviteUserPage";
 import SalesDashboard from "./app/sales/SalesDashboard";
 import NewJobBuilderPage from "./app/install-manager/job/NewJobBuilderPage";
 import AdminNewJob from "./app/admin/jobs/AdminNewJob";
@@ -132,6 +133,12 @@ export const ROUTES: RouteConfig[] = [
     element: React.createElement(AdminUserListPage),
     role: "Admin",
     label: "User Management",
+  },
+  {
+    path: "/admin/invite-user",
+    element: React.createElement(AdminInviteUserPage),
+    role: "Admin",
+    label: "Invite User",
   },
   {
     path: "/admin/jobs/new",


### PR DESCRIPTION
## Summary
- allow inviting new users with role
- add create_pending_user migration
- register the new page route for admins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685897ad75fc832d9461226781b0bc17