### PR TITLE
Add install scheduling calendar

### DIFF
--- a/installer-app/jest.config.js
+++ b/installer-app/jest.config.js
@@ -8,5 +8,7 @@ export default {
   transformIgnorePatterns: ['/node_modules/(?!(\\@supabase)/)'],
   moduleNameMapper: {
     '^react$': 'react',
+    '^.+\\.(css|less)$': 'identity-obj-proxy',
+    '^react-big-calendar\\/.*\\.css$': 'identity-obj-proxy',
   },
 };

--- a/installer-app/package-lock.json
+++ b/installer-app/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.50.0",
+        "date-fns": "^4.1.0",
         "react": "^18.2.0",
+        "react-big-calendar": "^1.19.4",
         "react-dom": "^18.2.0",
         "react-icons": "^5.5.0",
         "react-router-dom": "^6.23.0"
@@ -1918,7 +1920,6 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -4157,6 +4158,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
@@ -4164,6 +4175,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@restart/hooks": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
+      "integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -5647,17 +5670,13 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -5699,6 +5718,12 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/warning": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
+      "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -6569,6 +6594,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6776,9 +6810,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -6847,6 +6879,28 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/date-arithmetic": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-arithmetic/-/date-arithmetic-4.1.0.tgz",
+      "integrity": "sha512-QWxYLR5P/6GStZcdem+V1xoto6DMadYWpMXU82ES3/RfR3Wdwr3D0+be7mgOJ+Ov0G9D5Dmb9T17sNLQYj9XOg==",
+      "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -6989,7 +7043,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7048,6 +7101,16 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -8241,6 +8304,11 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/globalize": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/globalize/-/globalize-0.1.1.tgz",
+      "integrity": "sha512-5e01v8eLGfuQSOvx2MsDMOWS0GFtCx1wPzQSmcHw4hkxFzrQDBO3Xwg/m8Hr/7qXMrHeOIE29qWVzyv06u1TZA=="
+    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -8569,6 +8637,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/is-arguments": {
@@ -12013,7 +12090,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -12050,6 +12132,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lz-string": {
@@ -12127,6 +12218,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
     },
     "node_modules/memoizerific": {
       "version": "1.11.3",
@@ -12220,6 +12317,27 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -12325,7 +12443,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13014,7 +13131,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -13026,7 +13142,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -13087,6 +13202,34 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-big-calendar": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/react-big-calendar/-/react-big-calendar-1.19.4.tgz",
+      "integrity": "sha512-FrvbDx2LF6JAWFD96LU1jjloppC5OgIvMYUYIPzAw5Aq+ArYFPxAjLqXc4DyxfsQDN0TJTMuS/BIbcSB7Pg0YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "clsx": "^1.2.1",
+        "date-arithmetic": "^4.1.0",
+        "dayjs": "^1.11.7",
+        "dom-helpers": "^5.2.1",
+        "globalize": "^0.1.1",
+        "invariant": "^2.2.4",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "luxon": "^3.2.1",
+        "memoize-one": "^6.0.0",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.40",
+        "prop-types": "^15.8.1",
+        "react-overlays": "^5.2.1",
+        "uncontrollable": "^7.2.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.14.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-docgen": {
@@ -13165,6 +13308,32 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "license": "MIT"
+    },
+    "node_modules/react-overlays": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.2.1.tgz",
+      "integrity": "sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.8",
+        "@popperjs/core": "^2.11.6",
+        "@restart/hooks": "^0.4.7",
+        "@types/warning": "^3.0.0",
+        "dom-helpers": "^5.2.0",
+        "prop-types": "^15.7.2",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -14628,6 +14797,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/uncontrollable": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
+      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.6.3",
+        "@types/react": ">=16.9.11",
+        "invariant": "^2.2.4",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
@@ -14908,6 +15092,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/installer-app/package.json
+++ b/installer-app/package.json
@@ -13,7 +13,9 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.50.0",
+    "date-fns": "^4.1.0",
     "react": "^18.2.0",
+    "react-big-calendar": "^1.19.4",
     "react-dom": "^18.2.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^6.23.0"
@@ -22,6 +24,9 @@
     "@babel/preset-env": "^7.27.2",
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.24.0",
+    "@storybook/addon-essentials": "^8.6.14",
+    "@storybook/react": "^8.6.14",
+    "@storybook/react-vite": "^8.6.14",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
@@ -36,10 +41,7 @@
     "jest-environment-jsdom": "^30.0.0",
     "prettier": "^3.2.5",
     "tailwindcss": "^3.4.4",
-    "vite": "^6.3.5",
-    "@storybook/react-vite": "^8.6.14",
-    "@storybook/addon-essentials": "^8.6.14",
-    "@storybook/react": "^8.6.14"
+    "vite": "^6.3.5"
   },
   "resolutions": {
     "chalk": "4.1.2",

--- a/installer-app/src/app/install-manager/CalendarPage.tsx
+++ b/installer-app/src/app/install-manager/CalendarPage.tsx
@@ -1,0 +1,65 @@
+import React, { useMemo, useState } from 'react';
+import useJobs from '../../lib/hooks/useJobs';
+import useInstallers from '../../lib/hooks/useInstallers';
+import { JobCalendar, JobEvent } from '../../components/calendar/JobCalendar';
+import { useAuth } from '../../lib/hooks/useAuth';
+
+const CalendarPage: React.FC = () => {
+  const { jobs, updateScheduledDate, loading } = useJobs();
+  const { installers } = useInstallers();
+  const { role } = useAuth();
+  const [filter, setFilter] = useState<string>('all');
+
+  const events = useMemo(() => {
+    return jobs
+      .filter((j) => filter === 'all' || j.assigned_to === filter)
+      .map<JobEvent>((j) => ({
+        id: j.id,
+        title: j.address,
+        start: j.scheduled_date ? new Date(j.scheduled_date) : new Date(),
+        end: j.scheduled_date ? new Date(j.scheduled_date) : new Date(),
+        status: j.status,
+        assignedTo: j.assigned_to,
+      }));
+  }, [jobs, filter]);
+
+  const canEdit = role === 'Manager' || role === 'Admin';
+
+  const handleDrop = async (event: JobEvent, start: Date) => {
+    const dateStr = start.toISOString().slice(0, 10);
+    await updateScheduledDate(event.id, dateStr);
+  };
+
+  return (
+    <div className="p-4">
+      <header className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-bold">Job Schedule</h1>
+        <div>
+          <label htmlFor="installer" className="mr-2 text-sm font-medium">
+            Filter Installer
+          </label>
+          <select
+            id="installer"
+            className="border rounded px-2 py-1"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+          >
+            <option value="all">All</option>
+            {installers.map((i) => (
+              <option key={i.id} value={i.id}>
+                {i.full_name || i.id}
+              </option>
+            ))}
+          </select>
+        </div>
+      </header>
+      {loading ? (
+        <div>Loading...</div>
+      ) : (
+        <JobCalendar events={events} editable={canEdit} onEventDrop={handleDrop} />
+      )}
+    </div>
+  );
+};
+
+export default CalendarPage;

--- a/installer-app/src/components/calendar/JobCalendar.tsx
+++ b/installer-app/src/components/calendar/JobCalendar.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Calendar, dateFnsLocalizer, Views } from 'react-big-calendar';
+import withDragAndDrop, { withDragAndDropProps } from 'react-big-calendar/lib/addons/dragAndDrop';
+import { format, parse, startOfWeek, getDay } from 'date-fns';
+import enUS from 'date-fns/locale/en-US';
+
+const locales = {
+  'en-US': enUS,
+};
+
+const localizer = dateFnsLocalizer({
+  format,
+  parse,
+  startOfWeek,
+  getDay,
+  locales,
+});
+
+export interface JobEvent {
+  id: string;
+  title: string;
+  start: Date;
+  end: Date;
+  status: string;
+  assignedTo: string | null;
+}
+
+export interface JobCalendarProps {
+  events: JobEvent[];
+  onEventDrop?: (event: JobEvent, start: Date) => void;
+  editable?: boolean;
+}
+
+const statusColors: Record<string, string> = {
+  assigned: '#3b82f6',
+  in_progress: '#f59e0b',
+  needs_qa: '#f97316',
+  complete: '#10b981',
+  rework: '#ef4444',
+};
+
+const DnDCalendar = withDragAndDrop(Calendar as React.ComponentType<withDragAndDropProps<JobEvent>>);
+
+export const JobCalendar: React.FC<JobCalendarProps> = ({ events, onEventDrop, editable = true }) => {
+  return (
+    <DnDCalendar
+      localizer={localizer}
+      events={events}
+      defaultView={Views.WEEK}
+      views={[Views.WEEK, Views.MONTH]}
+      style={{ height: '80vh' }}
+      onEventDrop={({ event, start }) => onEventDrop?.(event as JobEvent, start)}
+      resizable={false}
+      draggableAccessor={(event) => editable && !!event.assignedTo}
+      eventPropGetter={(event) => {
+        const bg = statusColors[event.status] || '#6b7280';
+        return { style: { backgroundColor: bg, borderColor: bg } };
+      }}
+    />
+  );
+};
+
+export default JobCalendar;

--- a/installer-app/src/lib/hooks/useJobs.ts
+++ b/installer-app/src/lib/hooks/useJobs.ts
@@ -7,6 +7,8 @@ export interface Job {
   client_name?: string | null;
   contact_name: string;
   contact_phone: string;
+  address: string;
+  scheduled_date: string | null;
   assigned_to: string | null;
   status: string;
   created_at: string;
@@ -23,7 +25,7 @@ export function useJobs() {
     const { data, error } = await supabase
       .from("jobs")
       .select(
-        "id, client_id, contact_name, contact_phone, assigned_to, status, created_at, quote_id, clients(name)",
+        "id, client_id, contact_name, contact_phone, address, scheduled_date, assigned_to, status, created_at, quote_id, clients(name)"
       )
       .order("created_at", { ascending: false });
     if (error) {
@@ -45,7 +47,7 @@ export function useJobs() {
     const { data, error } = await supabase
       .from("jobs")
       .select(
-        "id, client_id, contact_name, contact_phone, assigned_to, status, created_at, quote_id, clients(name)",
+        "id, client_id, contact_name, contact_phone, address, scheduled_date, assigned_to, status, created_at, quote_id, clients(name)"
       )
       .eq("assigned_to", userId)
       .order("created_at", { ascending: false });
@@ -96,6 +98,21 @@ export function useJobs() {
     return data;
   }, []);
 
+  const updateScheduledDate = useCallback(
+    async (id: string, date: string) => {
+      setJobs((js) => js.map((j) => (j.id === id ? { ...j, scheduled_date: date } : j)));
+      const { error } = await supabase
+        .from('jobs')
+        .update({ scheduled_date: date })
+        .eq('id', id);
+      if (error) {
+        console.error(error);
+        await fetchJobs();
+      }
+    },
+    [fetchJobs],
+  );
+
   const updateStatus = async (jobId: string, newStatus: string) => {
     await supabase.from("jobs").update({ status: newStatus }).eq("id", jobId);
 
@@ -118,6 +135,7 @@ export function useJobs() {
     fetchJobs,
     createJob,
     assignJob,
+    updateScheduledDate,
     updateStatus,
   } as const;
 }

--- a/installer-app/src/routes.ts
+++ b/installer-app/src/routes.ts
@@ -9,6 +9,7 @@ import IFIDashboard from "./installer/pages/IFIDashboard";
 import MockJobsPage from "./installer/pages/MockJobsPage";
 import FeedbackPage from "./installer/pages/FeedbackPage";
 import InstallManagerDashboard from "./app/install-manager/page.jsx";
+import CalendarPage from "./app/install-manager/CalendarPage";
 import AdminDashboard from "./app/admin/AdminDashboard";
 import AdminUserListPage from "./app/admin/users/AdminUserListPage";
 import AdminInviteUserPage from "./app/admin/users/AdminInviteUserPage";
@@ -202,6 +203,12 @@ export const ROUTES: RouteConfig[] = [
     element: React.createElement(InstallManagerDashboard),
     role: ["Manager", "Admin"],
     label: "Install Manager Dashboard",
+  },
+  {
+    path: "/install-manager/calendar",
+    element: React.createElement(CalendarPage),
+    role: ["Manager", "Admin"],
+    label: "Schedule Calendar",
   },
   {
     path: "/install-manager/dashboard",


### PR DESCRIPTION
## Summary
- install `react-big-calendar` and `date-fns`
- create reusable `JobCalendar` component using drag-and-drop
- implement `CalendarPage` for install managers
- extend jobs hook with schedule update
- expose calendar route and update Jest config

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6858a2bb78cc832d9794418a49077435