### PR TITLE
Add icon prop to Global state components

### DIFF
--- a/installer-app/src/components/global-states/GlobalEmpty.tsx
+++ b/installer-app/src/components/global-states/GlobalEmpty.tsx
@@ -1,8 +1,22 @@
 import React from "react";
 
-export function GlobalEmpty({ message = "Nothing here yet." }: { message?: string }) {
+/**
+ * Placeholder component shown when there is no data to display.
+ *
+ * @param message Optional text to explain the empty state.
+ * @param icon Optional React node rendered before the message.
+ */
+
+export function GlobalEmpty({
+  message = "Nothing here yet.",
+  icon,
+}: {
+  message?: string;
+  icon?: React.ReactNode;
+}) {
   return (
-    <div className="p-4 text-gray-500 italic">
+    <div className="p-4 text-gray-500 italic flex items-center">
+      {icon && <span className="mr-2">{icon}</span>}
       <p>{message}</p>
     </div>
   );

--- a/installer-app/src/components/global-states/GlobalError.tsx
+++ b/installer-app/src/components/global-states/GlobalError.tsx
@@ -1,14 +1,33 @@
 import React from "react";
 
-export function GlobalError({ message = "Something went wrong.", onRetry }: { message?: string; onRetry?: () => void }) {
+/**
+ * Generic error message component.
+ *
+ * @param message Text to display to the user.
+ * @param onRetry Optional callback to retry the failed action.
+ * @param icon Optional React node rendered before the message.
+ */
+
+export function GlobalError({
+  message = "Something went wrong.",
+  onRetry,
+  icon,
+}: {
+  message?: string;
+  onRetry?: () => void;
+  icon?: React.ReactNode;
+}) {
   return (
-    <div className="p-4 text-red-600 border border-red-300 rounded bg-red-50">
-      <p className="mb-2 font-bold">{message}</p>
-      {onRetry && (
-        <button onClick={onRetry} className="text-sm underline">
-          Retry
-        </button>
-      )}
+    <div className="p-4 text-red-600 border border-red-300 rounded bg-red-50 flex items-start">
+      {icon && <span className="mr-2">{icon}</span>}
+      <div>
+        <p className="mb-2 font-bold">{message}</p>
+        {onRetry && (
+          <button onClick={onRetry} className="text-sm underline">
+            Retry
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/installer-app/src/components/global-states/GlobalLoading.tsx
+++ b/installer-app/src/components/global-states/GlobalLoading.tsx
@@ -1,8 +1,22 @@
 import React from "react";
 
-export function GlobalLoading({ message = "Loading..." }: { message?: string }) {
+/**
+ * Loading indicator displayed while data is fetching.
+ *
+ * @param message Text shown next to the spinner.
+ * @param icon Optional React node rendered before the message.
+ */
+
+export function GlobalLoading({
+  message = "Loading...",
+  icon,
+}: {
+  message?: string;
+  icon?: React.ReactNode;
+}) {
   return (
-    <div className="p-4 text-gray-600">
+    <div className="p-4 text-gray-600 flex items-center">
+      {icon && <span className="mr-2">{icon}</span>}
       <span className="animate-pulse">{message}</span>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow `GlobalError`, `GlobalLoading` and `GlobalEmpty` to render an optional icon before their messages
- document the new `icon` prop in component comments

## Testing
- `npm test --silent`
- `npm run build`
- `npm run lint` *(fails: ESLint configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858ad0c3cc4832d9777b6298b7f8629