### PR TITLE
Use global loading/error components

### DIFF
--- a/installer-app/src/installer/pages/AppointmentSummaryPage.jsx
+++ b/installer-app/src/installer/pages/AppointmentSummaryPage.jsx
@@ -11,6 +11,11 @@ import { useNavigate } from 'react-router-dom';
 import Header from '../components/Header';
 import SideDrawer from '../components/SideDrawer';
 import { useAppointments } from '../hooks/useInstallerData';
+import {
+  GlobalLoading,
+  GlobalError,
+  GlobalEmpty,
+} from '../../components/global-states';
 
 const AppointmentSummaryPage = ({ jobs }) => {
   const [showDrawer, setShowDrawer] = useState(false);
@@ -117,9 +122,11 @@ const AppointmentSummaryPage = ({ jobs }) => {
         <h1 className="text-2xl font-bold text-center mb-4">Appointment Summary</h1>
         <div className="space-y-4">
           {loading && !jobs ? (
-            <p className="text-center text-gray-500">Loading...</p>
+            <GlobalLoading />
           ) : error ? (
-            <p className="text-center text-red-500">{error}</p>
+            <GlobalError message={error} />
+          ) : data.length === 0 ? (
+            <GlobalEmpty message="No appointments found." />
           ) : (
             data.map((job) => {
               const status = computeStatus(job);

--- a/installer-app/src/installer/pages/IFIDashboard.jsx
+++ b/installer-app/src/installer/pages/IFIDashboard.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { useIFIScores } from '../hooks/useInstallerData';
+import { GlobalLoading } from '../../components/global-states';
 
 
 const IFIDashboard = () => {
   const { data, loading } = useIFIScores();
 
   if (loading || !data) {
-    return <div className="p-4 text-center">Loading...</div>;
+    return <GlobalLoading />;
   }
 
   const {

--- a/installer-app/src/installer/pages/JobDetailPage.tsx
+++ b/installer-app/src/installer/pages/JobDetailPage.tsx
@@ -11,6 +11,7 @@ import InstallerActionsPanel from "../../features/jobs/components/InstallerActio
 import { getJobById, JobDetail } from "../../features/jobs/jobService";
 import useAuth from "../../lib/hooks/useAuth";
 import uploadDocument from "../../lib/uploadDocument";
+import { GlobalLoading, GlobalError } from "../../components/global-states";
 
 const JobDetailPage: React.FC = () => {
   const { jobId } = useParams<{ jobId: string }>();
@@ -78,8 +79,8 @@ const JobDetailPage: React.FC = () => {
     navigate("/appointments");
   };
 
-  if (loading) return <p className="p-4">Loading job...</p>;
-  if (!job || error) return <p className="p-4 text-red-500">{error || "Job not found"}</p>;
+  if (loading) return <GlobalLoading message="Loading job..." />;
+  if (!job || error) return <GlobalError message={error || "Job not found"} />;
 
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col relative">


### PR DESCRIPTION
## Summary
- render `GlobalLoading`, `GlobalError`, and `GlobalEmpty` on appointment summary page
- swap raw placeholders for global components on job detail and IFI dashboard pages

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6858ad06c02c832d8e8c0c257bcaf102