### PR TITLE
Handle inventory alert errors

### DIFF
--- a/installer-app/src/__tests__/InventoryAlertsPage.test.tsx
+++ b/installer-app/src/__tests__/InventoryAlertsPage.test.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import InventoryAlertsPage from "../app/manager/InventoryAlertsPage";
+
+jest.mock("../lib/hooks/useInventoryLevels", () => ({
+  __esModule: true,
+  default: () => ({
+    alerts: [],
+    loading: false,
+    error: "Failed to load",
+    fetchAlerts: jest.fn(),
+    markResolved: jest.fn(),
+  }),
+}));
+
+test("displays error message when inventory hook fails", () => {
+  render(
+    <MemoryRouter>
+      <InventoryAlertsPage />
+    </MemoryRouter>,
+  );
+  expect(screen.getByText("Failed to load")).toBeInTheDocument();
+});

--- a/installer-app/src/app/manager/InventoryAlertsPage.tsx
+++ b/installer-app/src/app/manager/InventoryAlertsPage.tsx
@@ -3,16 +3,22 @@ import { Link } from "react-router-dom";
 import { SZTable } from "../../components/ui/SZTable";
 import { SZButton } from "../../components/ui/SZButton";
 import useInventoryLevels from "../../lib/hooks/useInventoryLevels";
-import { GlobalLoading, GlobalEmpty } from "../../components/global-states";
+import {
+  GlobalLoading,
+  GlobalEmpty,
+  GlobalError,
+} from "../../components/global-states";
 
 const InventoryAlertsPage: React.FC = () => {
-  const { alerts, loading, markResolved } = useInventoryLevels();
+  const { alerts, loading, error, fetchAlerts, markResolved } = useInventoryLevels();
 
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Low Stock Alerts</h1>
       {loading ? (
         <GlobalLoading />
+      ) : error ? (
+        <GlobalError message={error} onRetry={fetchAlerts} />
       ) : alerts.length === 0 ? (
         <GlobalEmpty message="No low stock alerts." />
       ) : (


### PR DESCRIPTION
## Summary
- display GlobalError when `useInventoryLevels` returns an error
- test error handling for `InventoryAlertsPage`

## Testing
- `npm test --prefix installer-app`

------
https://chatgpt.com/codex/tasks/task_e_6858ad06a718832dbd4aabe14eca6946