### PR TITLE
Consolidate dashboard routes

### DIFF
--- a/installer-app/src/app/login/LoginPage.tsx
+++ b/installer-app/src/app/login/LoginPage.tsx
@@ -20,9 +20,9 @@ const LoginPage: React.FC = () => {
     if (session && role) {
       if (role === "Admin") navigate("/admin/dashboard", { replace: true });
       else if (role === "Installer")
-        navigate("/installer/dashboard", { replace: true });
+        navigate("/installer", { replace: true });
       else if (role === "Manager")
-        navigate("/install-manager/dashboard", { replace: true });
+        navigate("/install-manager", { replace: true });
       else if (role === "Sales")
         navigate("/sales/dashboard", { replace: true });
       else navigate("/", { replace: true });

--- a/installer-app/src/components/layout/Header.tsx
+++ b/installer-app/src/components/layout/Header.tsx
@@ -11,7 +11,7 @@ const dashboardPath: Record<string, string> = {
   Admin: "/admin/dashboard",
   Manager: "/manager/dashboard",
   Sales: "/sales/dashboard",
-  Installer: "/installer/dashboard",
+  Installer: "/installer",
 };
 
 export const Header: React.FC<HeaderProps> = ({ onToggleSidebar }) => {

--- a/installer-app/src/components/layout/Sidebar.tsx
+++ b/installer-app/src/components/layout/Sidebar.tsx
@@ -47,7 +47,7 @@ const salesLinks: LinkItem[] = [
 ];
 
 const installerLinks: LinkItem[] = [
-  { to: "/installer/dashboard", label: "Dashboard" },
+  { to: "/installer", label: "Dashboard" },
   { to: "/installer/jobs", label: "My Jobs" },
   { to: "/installer/materials", label: "Material Logger" },
 ];

--- a/installer-app/src/components/navigation/Header.tsx
+++ b/installer-app/src/components/navigation/Header.tsx
@@ -11,7 +11,7 @@ const roleDashboard: Record<string, string> = {
   Admin: "/admin/dashboard",
   Manager: "/manager/dashboard",
   Sales: "/sales/dashboard",
-  Installer: "/installer/dashboard",
+  Installer: "/installer",
 };
 
 const Header: React.FC<Props> = ({ onToggleSidebar }) => {

--- a/installer-app/src/components/onboarding/OnboardingPanel.tsx
+++ b/installer-app/src/components/onboarding/OnboardingPanel.tsx
@@ -15,12 +15,12 @@ const TASKS_BY_ROLE: Record<string, { id: string; label: string; link: string }[
     { id: 'explore_crm', label: 'Explore the CRM Pipeline', link: '/crm/leads' },
   ],
   Manager: [
-    { id: 'review_jobs', label: 'Review Jobs in Progress', link: '/install-manager/dashboard' },
+    { id: 'review_jobs', label: 'Review Jobs in Progress', link: '/install-manager' },
     { id: 'approve_quotes', label: 'Approve Pending Quotes', link: '/quotes' },
     { id: 'payroll_report', label: 'Generate Payroll Report', link: '/reports/technician-pay' },
   ],
   Installer: [
-    { id: 'view_jobs', label: 'View Your Assigned Jobs', link: '/installer/dashboard' },
+    { id: 'view_jobs', label: 'View Your Assigned Jobs', link: '/installer' },
     { id: 'complete_test_job', label: 'Complete First Job (Test)', link: '/installer/jobs/mock' },
     { id: 'log_materials', label: 'Log Materials for a Job', link: '/installer/inventory' },
   ],

--- a/installer-app/src/routes.ts
+++ b/installer-app/src/routes.ts
@@ -103,11 +103,6 @@ export const ROUTES: RouteConfig[] = [
     label: "Installer Dashboard",
   },
   {
-    path: "/installer/dashboard",
-    element: React.createElement(InstallerDashboard),
-    role: "Installer",
-  },
-  {
     path: "/installer/jobs/:id",
     element: React.createElement(InstallerJobPage),
     role: "Installer",
@@ -209,11 +204,6 @@ export const ROUTES: RouteConfig[] = [
     element: React.createElement(CalendarPage),
     role: ["Manager", "Admin"],
     label: "Schedule Calendar",
-  },
-  {
-    path: "/install-manager/dashboard",
-    element: React.createElement(InstallManagerDashboard),
-    role: ["Manager", "Admin"],
   },
   {
     path: "/install-manager/job/new",


### PR DESCRIPTION
## Summary
- collapse redundant installer routes
- collapse redundant install-manager routes
- update login redirects and nav links to use new paths

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6858ad609f30832d803cb73503a5143f