### PR TITLE
Add admin user management with roles

### DIFF
--- a/installer-app/src/app/admin/users/AdminUsersPage.tsx
+++ b/installer-app/src/app/admin/users/AdminUsersPage.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import AdminInviteUserPage from "./AdminInviteUserPage";
+import AdminUserListPage from "./AdminUserListPage";
+
+const AdminUsersPage: React.FC = () => {
+  return (
+    <div className="p-4 space-y-6">
+      <AdminInviteUserPage />
+      <AdminUserListPage />
+    </div>
+  );
+};
+
+export default AdminUsersPage;
+

--- a/installer-app/src/routes.ts
+++ b/installer-app/src/routes.ts
@@ -11,8 +11,7 @@ import FeedbackPage from "./installer/pages/FeedbackPage";
 import InstallManagerDashboard from "./app/install-manager/page.jsx";
 import CalendarPage from "./app/install-manager/CalendarPage";
 import AdminDashboard from "./app/admin/AdminDashboard";
-import AdminUserListPage from "./app/admin/users/AdminUserListPage";
-import AdminInviteUserPage from "./app/admin/users/AdminInviteUserPage";
+import AdminUsersPage from "./app/admin/users/AdminUsersPage";
 import SalesDashboard from "./app/sales/SalesDashboard";
 import NewJobBuilderPage from "./app/install-manager/job/NewJobBuilderPage";
 import AdminNewJob from "./app/admin/jobs/AdminNewJob";
@@ -141,15 +140,9 @@ export const ROUTES: RouteConfig[] = [
   },
   {
     path: "/admin/users",
-    element: React.createElement(AdminUserListPage),
+    element: React.createElement(AdminUsersPage),
     role: "Admin",
     label: "User Management",
-  },
-  {
-    path: "/admin/invite-user",
-    element: React.createElement(AdminInviteUserPage),
-    role: "Admin",
-    label: "Invite User",
   },
   {
     path: "/admin/materials",


### PR DESCRIPTION
## Summary
- manage user roles via `user_roles` table
- add refreshRoles helper in `useAuth`
- update admin invite flow to insert into `user_roles`
- update user role editor to work with `user_roles`
- combine invite and list pages in new `AdminUsersPage`
- update routing for new admin users page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858ad650bc8832d95b1c4e0cf65a4f5