### PR TITLE
Add Finance and Install Manager roles

### DIFF
--- a/installer-app/api/migrations/030_add_finance_install_manager_roles.sql
+++ b/installer-app/api/migrations/030_add_finance_install_manager_roles.sql
@@ -1,0 +1,4 @@
+alter table user_roles drop constraint if exists user_roles_role_check;
+alter table user_roles
+  add constraint user_roles_role_check
+  check (role in ('Installer','Admin','Manager','Sales','Finance','Install Manager'));

--- a/installer-app/src/app/admin/users/AdminInviteUserPage.tsx
+++ b/installer-app/src/app/admin/users/AdminInviteUserPage.tsx
@@ -3,7 +3,14 @@ import { SZInput } from "../../../components/ui/SZInput";
 import { SZButton } from "../../../components/ui/SZButton";
 import supabase from "../../../lib/supabaseClient";
 
-const ROLES = ["Admin", "Installer", "Sales", "Manager"];
+const ROLES = [
+  "Admin",
+  "Installer",
+  "Sales",
+  "Manager",
+  "Finance",
+  "Install Manager",
+];
 
 type Toast = { message: string; success: boolean } | null;
 

--- a/installer-app/src/app/admin/users/UserRoleEditor.tsx
+++ b/installer-app/src/app/admin/users/UserRoleEditor.tsx
@@ -2,7 +2,14 @@ import { useEffect, useState } from "react";
 import { SZButton } from "../../../components/ui/SZButton";
 import { supabase } from "../../../lib/supabaseClient";
 
-const ALL_ROLES = ["Admin", "Manager", "Installer", "Sales", "Finance"];
+const ALL_ROLES = [
+  "Admin",
+  "Manager",
+  "Installer",
+  "Sales",
+  "Finance",
+  "Install Manager",
+];
 
 export default function UserRoleEditor({ userId }: { userId: string }) {
   const [role, setRole] = useState<string | null>(null);

--- a/installer-app/src/app/login/LoginPage.tsx
+++ b/installer-app/src/app/login/LoginPage.tsx
@@ -21,10 +21,12 @@ const LoginPage: React.FC = () => {
       if (role === "Admin") navigate("/admin/dashboard", { replace: true });
       else if (role === "Installer")
         navigate("/installer/dashboard", { replace: true });
-      else if (role === "Manager")
+      else if (role === "Manager" || role === "Install Manager")
         navigate("/install-manager/dashboard", { replace: true });
       else if (role === "Sales")
         navigate("/sales/dashboard", { replace: true });
+      else if (role === "Finance")
+        navigate("/admin/reports/payments", { replace: true });
       else navigate("/", { replace: true });
     } else if (session && getAvailableRoles().length > 1) {
       navigate("/select-role", { replace: true });

--- a/installer-app/src/components/layout/Header.tsx
+++ b/installer-app/src/components/layout/Header.tsx
@@ -12,6 +12,8 @@ const dashboardPath: Record<string, string> = {
   Manager: "/manager/dashboard",
   Sales: "/sales/dashboard",
   Installer: "/installer/dashboard",
+  Finance: "/admin/reports/payments",
+  "Install Manager": "/install-manager/dashboard",
 };
 
 export const Header: React.FC<HeaderProps> = ({ onToggleSidebar }) => {

--- a/installer-app/src/components/layout/Sidebar.tsx
+++ b/installer-app/src/components/layout/Sidebar.tsx
@@ -58,6 +58,10 @@ function getLinks(role: string | null): LinkItem[] {
       return adminLinks;
     case "Manager":
       return managerLinks;
+    case "Install Manager":
+      return managerLinks;
+    case "Finance":
+      return adminLinks;
     case "Sales":
       return salesLinks;
     default:

--- a/installer-app/src/components/navigation/Header.tsx
+++ b/installer-app/src/components/navigation/Header.tsx
@@ -12,6 +12,8 @@ const roleDashboard: Record<string, string> = {
   Manager: "/manager/dashboard",
   Sales: "/sales/dashboard",
   Installer: "/installer/dashboard",
+  Finance: "/admin/reports/payments",
+  "Install Manager": "/install-manager/dashboard",
 };
 
 const Header: React.FC<Props> = ({ onToggleSidebar }) => {

--- a/installer-app/src/lib/hooks/useAuth.tsx
+++ b/installer-app/src/lib/hooks/useAuth.tsx
@@ -4,7 +4,10 @@ import { GlobalLoading, GlobalError } from "../../components/global-states";
 
 function normalizeRole(role: string | null): string | null {
   if (!role) return null;
-  return role.charAt(0).toUpperCase() + role.slice(1).toLowerCase();
+  return role
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(" ");
 }
 
 type AuthContextType = {


### PR DESCRIPTION
## Summary
- allow new `Finance` and `Install Manager` roles in DB
- normalize multi-word roles in `useAuth`
- update role choices and navigation redirects for new roles
- let sidebar menu handle `Finance` and `Install Manager`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858ad57422c832da81246b2b21b2fde