### PR TITLE
Add install manager role and update policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ psql $DATABASE_URL -f installer-app/api/migrations/004_create_feedback.sql
 
 Run additional migration files in order when setting up new environments.
 
+### User Roles
+
+Available application roles:
+
+- Admin
+- Manager
+- Installer
+- Sales
+- Install Manager
+- Finance
+
+Roles are assigned in the `user_roles` table and validated against the `roles` lookup table.
+
 ---
 
 ## Notes

--- a/installer-app/api/migrations/007_jobs_rls.sql
+++ b/installer-app/api/migrations/007_jobs_rls.sql
@@ -3,13 +3,13 @@ alter table jobs enable row level security;
 create policy "Jobs Select Assigned" on jobs
   for select using (
     assigned_to = auth.uid()
-    or exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager'))
+    or exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager','Install Manager'))
   );
 
 create policy "Jobs Update Assigned" on jobs
   for update using (
     assigned_to = auth.uid()
-    or exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager'))
+    or exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager','Install Manager'))
   );
 
 create policy "Jobs Insert" on jobs

--- a/installer-app/api/migrations/008_create_job_materials_used.sql
+++ b/installer-app/api/migrations/008_create_job_materials_used.sql
@@ -14,7 +14,7 @@ create policy "JobMaterialsUsed Select" on job_materials_used
   for select using (
     installer_id = auth.uid()
     or exists (
-      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager')
+      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager','Install Manager')
     )
   );
 

--- a/installer-app/api/migrations/009_create_qa_reviews.sql
+++ b/installer-app/api/migrations/009_create_qa_reviews.sql
@@ -12,13 +12,13 @@ alter table qa_reviews enable row level security;
 create policy "QAReviews Select" on qa_reviews
   for select using (
     exists (
-      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager')
+      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager','Install Manager')
     )
   );
 
 create policy "QAReviews Insert" on qa_reviews
   for insert with check (
     exists (
-      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager')
+      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager','Install Manager')
     )
   );

--- a/installer-app/api/migrations/013_create_installer_inventory.sql
+++ b/installer-app/api/migrations/013_create_installer_inventory.sql
@@ -11,7 +11,7 @@ create policy "InstallerInventory Select" on installer_inventory
   for select using (
     installer_id = auth.uid()
     or exists (
-      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager')
+      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager','Install Manager')
     )
   );
 
@@ -19,7 +19,7 @@ create policy "InstallerInventory Insert" on installer_inventory
   for insert with check (
     installer_id = auth.uid()
     or exists (
-      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager')
+      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager','Install Manager')
     )
   );
 
@@ -27,6 +27,6 @@ create policy "InstallerInventory Update" on installer_inventory
   for update using (
     installer_id = auth.uid()
     or exists (
-      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager')
+      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager','Install Manager')
     )
   );

--- a/installer-app/api/migrations/015_add_sales_role.sql
+++ b/installer-app/api/migrations/015_add_sales_role.sql
@@ -1,4 +1,4 @@
 alter table user_roles drop constraint if exists user_roles_role_check;
 alter table user_roles
   add constraint user_roles_role_check
-  check (role in ('Installer','Admin','Manager','Sales'));
+  check (role in ('Installer','Admin','Manager','Install Manager','Sales'));

--- a/installer-app/api/migrations/016_create_leads.sql
+++ b/installer-app/api/migrations/016_create_leads.sql
@@ -19,19 +19,19 @@ alter table leads enable row level security;
 create policy "Leads Select" on leads
   for select using (
     sales_rep_id = auth.uid() or
-    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Sales','Manager','Admin'))
+    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Sales','Manager','Admin','Install Manager'))
   );
 
 create policy "Leads Insert" on leads
   for insert with check (
     sales_rep_id = auth.uid() or
-    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Sales','Manager','Admin'))
+    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Sales','Manager','Admin','Install Manager'))
   );
 
 create policy "Leads Update" on leads
   for update using (
     sales_rep_id = auth.uid() or
-    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Sales','Manager','Admin'))
+    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Sales','Manager','Admin','Install Manager'))
   );
 
 create or replace function set_lead_audit_fields()

--- a/installer-app/api/migrations/017_create_lead_status_history.sql
+++ b/installer-app/api/migrations/017_create_lead_status_history.sql
@@ -11,7 +11,7 @@ alter table lead_status_history enable row level security;
 
 create policy "Lead status history access" on lead_status_history
   for select using (
-    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Sales','Manager','Admin'))
+    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Sales','Manager','Admin','Install Manager'))
   );
 
 create or replace function log_lead_status_change()

--- a/installer-app/api/migrations/018_update_jobs_for_lead_conversion.sql
+++ b/installer-app/api/migrations/018_update_jobs_for_lead_conversion.sql
@@ -7,6 +7,6 @@ drop policy if exists "Jobs Insert" on jobs;
 create policy "Jobs Insert" on jobs
   for insert with check (
     exists (
-      select 1 from user_roles where user_id = auth.uid() and role in ('Sales','Manager','Admin')
+      select 1 from user_roles where user_id = auth.uid() and role in ('Sales','Manager','Admin','Install Manager')
     )
   );

--- a/installer-app/api/migrations/019_clients_rls.sql
+++ b/installer-app/api/migrations/019_clients_rls.sql
@@ -3,17 +3,17 @@ alter table clients enable row level security;
 drop policy if exists "Clients Select" on clients;
 create policy "Clients Select" on clients
   for select using (
-    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Sales','Manager','Admin'))
+    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Sales','Manager','Admin','Install Manager'))
   );
 
 drop policy if exists "Clients Insert" on clients;
 create policy "Clients Insert" on clients
   for insert with check (
-    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Sales','Manager','Admin'))
+    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Sales','Manager','Admin','Install Manager'))
   );
 
 drop policy if exists "Clients Update" on clients;
 create policy "Clients Update" on clients
   for update using (
-    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Sales','Manager','Admin'))
+    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Sales','Manager','Admin','Install Manager'))
   );

--- a/installer-app/api/migrations/021_create_invoices.sql
+++ b/installer-app/api/migrations/021_create_invoices.sql
@@ -25,20 +25,20 @@ alter table invoices enable row level security;
 create policy "Invoices Select" on invoices for select using (true);
 create policy "Invoices Insert" on invoices
   for insert with check (
-    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Sales'))
+    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Sales','Install Manager'))
   );
 create policy "Invoices Update" on invoices
   for update using (
-    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Sales'))
+    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Sales','Install Manager'))
   );
 
 alter table invoice_line_items enable row level security;
 create policy "InvoiceLineItems Select" on invoice_line_items for select using (true);
 create policy "InvoiceLineItems Insert" on invoice_line_items
   for insert with check (
-    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Sales'))
+    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Sales','Install Manager'))
   );
 create policy "InvoiceLineItems Update" on invoice_line_items
   for update using (
-    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Sales'))
+    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Sales','Install Manager'))
   );

--- a/installer-app/api/migrations/021_create_job_qa_reviews.sql
+++ b/installer-app/api/migrations/021_create_job_qa_reviews.sql
@@ -12,13 +12,13 @@ alter table job_qa_reviews enable row level security;
 create policy "JobQAReviews Select" on job_qa_reviews
   for select using (
     exists (
-      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager')
+      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager','Install Manager')
     )
   );
 
 create policy "JobQAReviews Insert" on job_qa_reviews
   for insert with check (
     exists (
-      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager')
+      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager','Install Manager')
     )
   );

--- a/installer-app/api/migrations/024_create_job_quantities_completed.sql
+++ b/installer-app/api/migrations/024_create_job_quantities_completed.sql
@@ -12,7 +12,7 @@ alter table job_quantities_completed enable row level security;
 create policy "JobQuantitiesCompleted Select" on job_quantities_completed
   for select using (
     user_id = auth.uid()
-    or exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager'))
+    or exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager','Install Manager'))
   );
 
 create policy "JobQuantitiesCompleted Insert" on job_quantities_completed

--- a/installer-app/api/migrations/024_create_payments.sql
+++ b/installer-app/api/migrations/024_create_payments.sql
@@ -18,7 +18,7 @@ create policy "Payments Select" on payments for select using (true);
 create policy "Payments Insert" on payments
   for insert with check (
     exists (
-      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager','Sales','Installer')
+      select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager','Install Manager','Sales','Installer')
     )
   );
 

--- a/installer-app/api/migrations/025_create_signed_checklists.sql
+++ b/installer-app/api/migrations/025_create_signed_checklists.sql
@@ -11,7 +11,7 @@ alter table signed_checklists enable row level security;
 create policy "SignedChecklists Select" on signed_checklists
   for select using (
     installer_id = auth.uid()
-    or exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager'))
+    or exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager','Install Manager'))
   );
 
 create policy "SignedChecklists Insert" on signed_checklists

--- a/installer-app/api/migrations/026_create_payments.sql
+++ b/installer-app/api/migrations/026_create_payments.sql
@@ -14,10 +14,10 @@ alter table payments enable row level security;
 
 create policy "Payments Select" on payments
   for select using (
-    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager','Finance'))
+    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager','Install Manager','Finance'))
   );
 
 create policy "Payments Insert" on payments
   for insert with check (
-    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager','Finance'))
+    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Manager','Install Manager','Finance'))
   );

--- a/installer-app/api/migrations/031_standardize_user_roles.sql
+++ b/installer-app/api/migrations/031_standardize_user_roles.sql
@@ -1,0 +1,25 @@
+BEGIN;
+
+-- Create a lookup table for valid roles
+create table if not exists roles (
+  role text primary key
+);
+
+insert into roles(role) values
+  ('Installer'),('Admin'),('Manager'),('Sales'),('Install Manager'),('Finance')
+  on conflict do nothing;
+
+-- Update user_roles constraint to include all valid roles
+alter table user_roles drop constraint if exists user_roles_role_check;
+alter table user_roles add constraint user_roles_role_check
+  check (role in ('Installer','Admin','Manager','Sales','Install Manager','Finance'));
+
+-- Migrate any remaining values from users.role into user_roles
+insert into user_roles (user_id, role)
+select id, role from users where role is not null
+on conflict (user_id) do update set role = excluded.role;
+
+-- Remove deprecated column
+alter table users drop column if exists role;
+
+COMMIT;

--- a/installer-app/api/migrations/V4_add_invoice_financial_fields.sql
+++ b/installer-app/api/migrations/V4_add_invoice_financial_fields.sql
@@ -18,13 +18,13 @@ alter table invoice_fees enable row level security;
 create policy "InvoiceFees Select" on invoice_fees for select using (true);
 create policy "InvoiceFees Insert" on invoice_fees
   for insert with check (
-    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Sales'))
+    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Sales','Install Manager'))
   );
 create policy "InvoiceFees Update" on invoice_fees
   for update using (
-    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Sales'))
+    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Sales','Install Manager'))
   );
 create policy "InvoiceFees Delete" on invoice_fees
   for delete using (
-    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Sales'))
+    exists (select 1 from user_roles where user_id = auth.uid() and role in ('Admin','Sales','Install Manager'))
   );

--- a/installer-app/src/app/admin/TechnicianPayReport.jsx
+++ b/installer-app/src/app/admin/TechnicianPayReport.jsx
@@ -10,7 +10,8 @@ export default function TechnicianPayReport() {
   const [end, setEnd] = useState('');
   const rows = usePayReport(start, end);
 
-  if (!['Admin', 'Manager'].includes(role ?? '')) return <div className="p-4">Access denied</div>;
+  if (!['Admin', 'Manager', 'Install Manager'].includes(role ?? ''))
+    return <div className="p-4">Access denied</div>;
 
   const total = rows.reduce((s, r) => s + r.payout, 0);
 

--- a/installer-app/src/app/admin/users/AdminInviteUserPage.tsx
+++ b/installer-app/src/app/admin/users/AdminInviteUserPage.tsx
@@ -4,7 +4,14 @@ import { SZButton } from "../../../components/ui/SZButton";
 import supabase from "../../../lib/supabaseClient";
 import { useAuth } from "../../../lib/hooks/useAuth";
 
-const ROLES = ["Admin", "Installer", "Sales", "Manager"];
+const ROLES = [
+  "Admin",
+  "Installer",
+  "Sales",
+  "Manager",
+  "Install Manager",
+  "Finance",
+];
 
 type Toast = { message: string; success: boolean } | null;
 

--- a/installer-app/src/app/admin/users/UserRoleEditor.tsx
+++ b/installer-app/src/app/admin/users/UserRoleEditor.tsx
@@ -3,21 +3,26 @@ import { SZButton } from "../../../components/ui/SZButton";
 import { supabase } from "../../../lib/supabaseClient";
 import { useAuth } from "../../../lib/hooks/useAuth";
 
-const ALL_ROLES = ["Admin", "Manager", "Installer", "Sales", "Finance"];
+const ALL_ROLES = [
+  "Admin",
+  "Manager",
+  "Installer",
+  "Sales",
+  "Install Manager",
+  "Finance",
+];
 
 export default function UserRoleEditor({ userId }: { userId: string }) {
   const [role, setRole] = useState<string | null>(null);
-  const { user, refreshRoles } = useAuth();WW
+  const { user, refreshRoles } = useAuth();
 
   useEffect(() => {
     const fetch = async () => {
-      const { data } = await supabase
-        .from("user_roles")
-        .select("role")
-        .eq("user_id", userId)
-        .single();
-
-        .maybeSingle();
+        const { data } = await supabase
+          .from("user_roles")
+          .select("role")
+          .eq("user_id", userId)
+          .maybeSingle();
       setRole(data?.role ?? null);
     };
     fetch();

--- a/installer-app/src/app/install-manager/CalendarPage.tsx
+++ b/installer-app/src/app/install-manager/CalendarPage.tsx
@@ -24,7 +24,7 @@ const CalendarPage: React.FC = () => {
       }));
   }, [jobs, filter]);
 
-  const canEdit = role === 'Manager' || role === 'Admin';
+  const canEdit = role === 'Manager' || role === 'Install Manager' || role === 'Admin';
 
   const handleDrop = async (event: JobEvent, start: Date) => {
     const dateStr = start.toISOString().slice(0, 10);

--- a/installer-app/src/app/install-manager/InvoiceBuilderPage.jsx
+++ b/installer-app/src/app/install-manager/InvoiceBuilderPage.jsx
@@ -31,7 +31,7 @@ export default function InvoiceBuilderPage() {
     }
   }, [jobId, jobs, quotes]);
 
-  if (role !== 'InstallManager' && role !== 'Admin') return <div className="p-4">Access denied</div>;
+  if (role !== 'Install Manager' && role !== 'Admin') return <div className="p-4">Access denied</div>;
 
   const save = async () => {
     const amt = Number(amount);

--- a/installer-app/src/app/install-manager/quotes/QuoteBuilderPage.tsx
+++ b/installer-app/src/app/install-manager/quotes/QuoteBuilderPage.tsx
@@ -64,7 +64,7 @@ export default function QuoteBuilderPage() {
     alert(`Quote ${send ? 'sent' : 'saved'} successfully.`);
   };
 
-  if (role !== 'InstallManager') {
+  if (role !== 'Install Manager') {
     return <div className="p-4 text-red-600">Access denied.</div>;
   }
 

--- a/installer-app/src/app/install-manager/quotes/QuoteListPage.tsx
+++ b/installer-app/src/app/install-manager/quotes/QuoteListPage.tsx
@@ -17,7 +17,7 @@ const QuoteListPage: React.FC = () => {
   const [sort, setSort] = useState<"new" | "old" | "total">("new");
 
   if (authLoading) return <GlobalLoading />;
-  if (role !== "InstallManager" && role !== "Admin") {
+  if (role !== "Install Manager" && role !== "Admin") {
     return <Navigate to="/" replace />;
   }
 

--- a/installer-app/src/app/login/LoginPage.tsx
+++ b/installer-app/src/app/login/LoginPage.tsx
@@ -21,7 +21,7 @@ const LoginPage: React.FC = () => {
       if (role === "Admin") navigate("/admin/dashboard", { replace: true });
       else if (role === "Installer")
         navigate("/installer", { replace: true });
-      else if (role === "Manager")
+      else if (role === "Manager" || role === "Install Manager")
         navigate("/install-manager", { replace: true });
       else if (role === "Sales")
         navigate("/sales/dashboard", { replace: true });

--- a/installer-app/src/app/sales/CRMPipelineView.jsx
+++ b/installer-app/src/app/sales/CRMPipelineView.jsx
@@ -9,7 +9,8 @@ export default function CRMPipelineView() {
   const { role, user } = useAuth();
   const { leads, fetchLeads } = useLeads();
 
-  if (!['Sales', 'Manager'].includes(role ?? '')) return <div className="p-4">Access denied</div>;
+  if (!['Sales', 'Manager', 'Install Manager'].includes(role ?? ''))
+    return <div className="p-4">Access denied</div>;
 
   const onDrop = async (e, status) => {
     const id = e.dataTransfer.getData('text');

--- a/installer-app/src/app/sales/QuoteListPage.jsx
+++ b/installer-app/src/app/sales/QuoteListPage.jsx
@@ -10,7 +10,7 @@ export default function QuoteListPage() {
   const [status, setStatus] = useState('all');
   const [search, setSearch] = useState('');
 
-  if (!['Sales', 'Manager', 'Admin'].includes(role ?? '')) {
+  if (!['Sales', 'Manager', 'Install Manager', 'Admin'].includes(role ?? '')) {
     return <div className="p-4">Access denied</div>;
   }
 

--- a/installer-app/src/components/layout/Sidebar.tsx
+++ b/installer-app/src/components/layout/Sidebar.tsx
@@ -57,6 +57,7 @@ function getLinks(role: string | null): LinkItem[] {
     case "Admin":
       return adminLinks;
     case "Manager":
+    case "Install Manager":
       return managerLinks;
     case "Sales":
       return salesLinks;

--- a/installer-app/src/lib/hooks/useLead.ts
+++ b/installer-app/src/lib/hooks/useLead.ts
@@ -30,7 +30,11 @@ export default function useLead(leadId: string | null) {
   const [history, setHistory] = useState<LeadHistoryEntry[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
 
-  const allowed = role === "Sales" || role === "Manager" || role === "Admin";
+  const allowed =
+    role === "Sales" ||
+    role === "Manager" ||
+    role === "Install Manager" ||
+    role === "Admin";
 
   const fetchLead = useCallback(async () => {
     if (!leadId || !allowed) {

--- a/installer-app/src/lib/hooks/useLeads.ts
+++ b/installer-app/src/lib/hooks/useLeads.ts
@@ -19,7 +19,11 @@ export default function useLeads() {
   const [leads, setLeads] = useState<Lead[]>([]);
   const [loading, setLoading] = useState(true);
 
-  const allowed = role === "Sales" || role === "Manager" || role === "Admin";
+  const allowed =
+    role === "Sales" ||
+    role === "Manager" ||
+    role === "Install Manager" ||
+    role === "Admin";
 
   const fetchLeads = useCallback(
     async (status?: string) => {

--- a/schema-lock.sql
+++ b/schema-lock.sql
@@ -604,13 +604,23 @@ CREATE TABLE public.signed_checklists (
 ALTER TABLE public.signed_checklists OWNER TO postgres;
 
 --
+-- Name: roles; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.roles (
+    role text NOT NULL
+);
+
+ALTER TABLE public.roles OWNER TO postgres;
+
+--
 -- Name: user_roles; Type: TABLE; Schema: public; Owner: postgres
 --
 
 CREATE TABLE public.user_roles (
     user_id uuid NOT NULL,
     role text NOT NULL,
-    CONSTRAINT user_roles_role_check CHECK ((role = ANY (ARRAY['Installer'::text, 'Admin'::text, 'Manager'::text, 'Sales'::text])))
+    CONSTRAINT user_roles_role_check CHECK ((role = ANY (ARRAY['Installer'::text, 'Admin'::text, 'Manager'::text, 'Sales'::text, 'Install Manager'::text, 'Finance'::text])))
 );
 
 


### PR DESCRIPTION
## Summary
- add `Install Manager` and `Finance` roles
- migrate remaining roles to `user_roles` and drop `users.role`
- update RLS policies for new roles
- refresh user role dropdowns and role checks in UI
- document roles in README
- update schema-lock

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858b1babca4832db143c5db1f97cd05