### PR TITLE
Add Material Types admin UI with RLS

### DIFF
--- a/installer-app/api/migrations/034_create_materials.sql
+++ b/installer-app/api/migrations/034_create_materials.sql
@@ -1,0 +1,57 @@
+create table if not exists materials (
+  id uuid primary key default uuid_generate_v4(),
+  name text not null,
+  unit_of_measure text not null,
+  default_cost numeric,
+  retail_price numeric,
+  created_by uuid references auth.users(id),
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create or replace function update_timestamp()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger materials_set_updated
+before update on materials
+for each row
+execute procedure update_timestamp();
+
+alter table materials enable row level security;
+
+create policy "Allow all roles to view materials"
+on materials for select
+using (auth.uid() is not null);
+
+create policy "Allow Admin to create materials"
+on materials for insert
+with check (
+  exists (
+    select 1 from user_roles
+    where user_id = auth.uid() and role = 'Admin'
+  )
+);
+
+create policy "Allow Admin to update materials"
+on materials for update
+using (
+  exists (
+    select 1 from user_roles
+    where user_id = auth.uid() and role = 'Admin'
+  )
+)
+with check (true);
+
+create policy "Allow Admin to delete materials"
+on materials for delete
+using (
+  exists (
+    select 1 from user_roles
+    where user_id = auth.uid() and role = 'Admin'
+  )
+);

--- a/installer-app/src/app/admin/materials/MaterialTypesPage.tsx
+++ b/installer-app/src/app/admin/materials/MaterialTypesPage.tsx
@@ -1,0 +1,100 @@
+import React, { useState } from "react";
+import { SZButton } from "../../../components/ui/SZButton";
+import { SZTable } from "../../../components/ui/SZTable";
+import { GlobalLoading, GlobalError } from "../../../components/global-states";
+import useMaterialTypes, {
+  MaterialType,
+} from "../../../lib/hooks/useMaterialTypes";
+import MaterialTypeForm from "../../../components/forms/MaterialTypeForm";
+
+const emptyMaterial: Omit<MaterialType, "id" | "created_at"> = {
+  name: "",
+  unit_of_measure: "",
+  default_cost: 0,
+  retail_price: 0,
+};
+
+const MaterialTypesPage: React.FC = () => {
+  const {
+    materials,
+    loading,
+    error,
+    createMaterial,
+    updateMaterial,
+    deleteMaterial,
+  } = useMaterialTypes();
+  const [current, setCurrent] = useState<MaterialType | null>(null);
+
+  const save = async (
+    data: Omit<MaterialType, "id" | "created_at">,
+    id?: string,
+  ) => {
+    if (id) await updateMaterial(id, data);
+    else await createMaterial(data);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Material Types</h1>
+      <SZButton
+        size="sm"
+        onClick={() =>
+          setCurrent({ id: "new", created_at: "", ...emptyMaterial })
+        }
+      >
+        New Material
+      </SZButton>
+      {loading ? (
+        <GlobalLoading />
+      ) : error ? (
+        <GlobalError message={error} onRetry={() => {}} />
+      ) : (
+        <SZTable
+          headers={[
+            "Name",
+            "Unit",
+            "Default Cost",
+            "Retail Price",
+            "Created At",
+            "",
+          ]}
+        >
+          {materials.map((m) => (
+            <tr key={m.id} className="border-t">
+              <td className="p-2 border">{m.name}</td>
+              <td className="p-2 border">{m.unit_of_measure}</td>
+              <td className="p-2 border text-right">{m.default_cost ?? "-"}</td>
+              <td className="p-2 border text-right">{m.retail_price ?? "-"}</td>
+              <td className="p-2 border text-sm text-gray-500">
+                {new Date(m.created_at).toLocaleDateString()}
+              </td>
+              <td className="p-2 border space-x-2">
+                <SZButton size="xs" onClick={() => setCurrent(m)}>
+                  Edit
+                </SZButton>
+                <SZButton
+                  size="xs"
+                  variant="secondary"
+                  onClick={() => deleteMaterial(m.id)}
+                >
+                  Delete
+                </SZButton>
+              </td>
+            </tr>
+          ))}
+        </SZTable>
+      )}
+      {current && (
+        <MaterialTypeForm
+          material={current.id === "new" ? undefined : current}
+          onSave={async (data) => {
+            await save(data, current.id === "new" ? undefined : current.id);
+          }}
+          onClose={() => setCurrent(null)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default MaterialTypesPage;

--- a/installer-app/src/components/forms/MaterialTypeForm.tsx
+++ b/installer-app/src/components/forms/MaterialTypeForm.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from "react";
+import ModalWrapper from "../../installer/components/ModalWrapper";
+import { SZInput } from "../ui/SZInput";
+import { SZButton } from "../ui/SZButton";
+import { MaterialType } from "../../lib/hooks/useMaterialTypes";
+
+interface Props {
+  material?: MaterialType;
+  onSave: (data: Omit<MaterialType, "id" | "created_at">) => Promise<void>;
+  onClose: () => void;
+}
+
+const MaterialTypeForm: React.FC<Props> = ({ material, onSave, onClose }) => {
+  const [form, setForm] = useState<Omit<MaterialType, "id" | "created_at">>({
+    name: material?.name ?? "",
+    unit_of_measure: material?.unit_of_measure ?? "",
+    default_cost: material?.default_cost ?? 0,
+    retail_price: material?.retail_price ?? 0,
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  const save = async () => {
+    if (!form.name) {
+      setError("Name is required");
+      return;
+    }
+    if (!form.unit_of_measure) {
+      setError("Unit of measure is required");
+      return;
+    }
+    try {
+      await onSave(form);
+      onClose();
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <ModalWrapper isOpen={true} onClose={onClose}>
+      <h2 className="text-lg font-semibold mb-4">
+        {material ? "Edit Material" : "New Material"}
+      </h2>
+      <div className="space-y-2">
+        <SZInput
+          id="mat_name"
+          label="Name"
+          value={form.name}
+          onChange={(v) => setForm((f) => ({ ...f, name: v }))}
+        />
+        <SZInput
+          id="mat_uom"
+          label="Unit of Measure"
+          value={form.unit_of_measure}
+          onChange={(v) => setForm((f) => ({ ...f, unit_of_measure: v }))}
+        />
+        <SZInput
+          id="mat_default_cost"
+          label="Default Cost"
+          type="number"
+          value={String(form.default_cost ?? 0)}
+          onChange={(v) => setForm((f) => ({ ...f, default_cost: Number(v) }))}
+        />
+        <SZInput
+          id="mat_retail_price"
+          label="Retail Price"
+          type="number"
+          value={String(form.retail_price ?? 0)}
+          onChange={(v) => setForm((f) => ({ ...f, retail_price: Number(v) }))}
+        />
+        {error && <p className="text-sm text-red-600">{error}</p>}
+      </div>
+      <div className="mt-4 flex justify-end gap-2">
+        <SZButton variant="secondary" onClick={onClose}>
+          Cancel
+        </SZButton>
+        <SZButton onClick={save}>Save</SZButton>
+      </div>
+    </ModalWrapper>
+  );
+};
+
+export default MaterialTypeForm;

--- a/installer-app/src/lib/hooks/useMaterialTypes.ts
+++ b/installer-app/src/lib/hooks/useMaterialTypes.ts
@@ -1,0 +1,84 @@
+import { useState, useEffect, useCallback } from "react";
+import supabase from "../supabaseClient";
+
+export interface MaterialType {
+  id: string;
+  name: string;
+  unit_of_measure: string;
+  default_cost: number | null;
+  retail_price: number | null;
+  created_at: string;
+}
+
+export default function useMaterialTypes() {
+  const [materials, setMaterials] = useState<MaterialType[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchMaterials = useCallback(async () => {
+    setLoading(true);
+    const { data, error } = await supabase
+      .from<MaterialType>("materials")
+      .select(
+        "id, name, unit_of_measure, default_cost, retail_price, created_at",
+      )
+      .order("created_at", { ascending: false });
+    if (error) {
+      setError(error.message);
+      setMaterials([]);
+    } else {
+      setError(null);
+      setMaterials(data ?? []);
+    }
+    setLoading(false);
+  }, []);
+
+  const createMaterial = useCallback(
+    async (input: Omit<MaterialType, "id" | "created_at">) => {
+      const { data, error } = await supabase
+        .from<MaterialType>("materials")
+        .insert(input)
+        .select()
+        .single();
+      if (error) throw error;
+      setMaterials((list) => [data, ...list]);
+      return data;
+    },
+    [],
+  );
+
+  const updateMaterial = useCallback(
+    async (id: string, input: Omit<MaterialType, "id" | "created_at">) => {
+      const { data, error } = await supabase
+        .from<MaterialType>("materials")
+        .update(input)
+        .eq("id", id)
+        .select()
+        .single();
+      if (error) throw error;
+      setMaterials((list) => list.map((m) => (m.id === id ? data : m)));
+      return data;
+    },
+    [],
+  );
+
+  const deleteMaterial = useCallback(async (id: string) => {
+    const { error } = await supabase.from("materials").delete().eq("id", id);
+    if (error) throw error;
+    setMaterials((list) => list.filter((m) => m.id !== id));
+  }, []);
+
+  useEffect(() => {
+    fetchMaterials();
+  }, [fetchMaterials]);
+
+  return {
+    materials,
+    loading,
+    error,
+    fetchMaterials,
+    createMaterial,
+    updateMaterial,
+    deleteMaterial,
+  } as const;
+}

--- a/installer-app/src/routes.ts
+++ b/installer-app/src/routes.ts
@@ -16,7 +16,7 @@ import SalesDashboard from "./app/sales/SalesDashboard";
 import NewJobBuilderPage from "./app/install-manager/job/NewJobBuilderPage";
 import AdminNewJob from "./app/admin/jobs/AdminNewJob";
 import AdminJobDetail from "./app/admin/jobs/JobDetailPage";
-import MaterialListPage from "./app/admin/materials/MaterialListPage";
+import MaterialTypesPage from "./app/admin/materials/MaterialTypesPage";
 import InstallerDashboard from "./app/installer/InstallerDashboard";
 import InstallerJobPage from "./app/installer/jobs/InstallerJobPage";
 import InstallerProfilePage from "./app/installer/profile/InstallerProfilePage";
@@ -140,8 +140,8 @@ export const ROUTES: RouteConfig[] = [
     label: "User Management",
   },
   {
-    path: "/admin/materials",
-    element: React.createElement(MaterialListPage),
+    path: "/admin/materials/types",
+    element: React.createElement(MaterialTypesPage),
     role: "Admin",
     label: "Material Types",
   },


### PR DESCRIPTION
## Summary
- create `materials` table with secure RLS
- add React hooks and forms for Material Types CRUD
- add MaterialTypesPage and route `/admin/materials/types`

## Testing
- `npm test` *(fails: 2 failed, 21 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6858c40ce670832dbdcebaa0498617b6