### PR TITLE
Add RPC to convert quotes to jobs

### DIFF
--- a/installer-app/api/migrations/034_convert_quote_to_job.sql
+++ b/installer-app/api/migrations/034_convert_quote_to_job.sql
@@ -1,0 +1,80 @@
+-- Add status column to quotes if missing
+alter table quotes add column if not exists status text default 'draft';
+
+-- Ensure job_materials has required columns
+alter table job_materials add column if not exists job_id uuid;
+alter table job_materials add column if not exists material_id uuid;
+alter table job_materials add column if not exists quantity integer;
+
+-- RPC to convert quote into job
+create or replace function convert_quote_to_job(quote_id uuid)
+returns uuid
+language plpgsql
+security definer
+as $$
+declare
+  quote_record record;
+  new_job_id uuid;
+begin
+  -- Fetch quote
+  select * into quote_record from quotes where id = quote_id;
+  if not found then
+    raise exception 'Quote not found';
+  end if;
+
+  if quote_record.status != 'approved' then
+    raise exception 'Quote must be approved';
+  end if;
+
+  -- Create job
+  insert into jobs (client_id, quote_id, status, created_by)
+  values (quote_record.client_id, quote_id, 'created', auth.uid())
+  returning id into new_job_id;
+
+  -- Copy quote items into job materials
+  insert into job_materials (job_id, material_id, quantity)
+  select new_job_id, material_id, quantity
+  from quote_items
+  where quote_id = quote_id;
+
+  -- Update quote status
+  update quotes set status = 'converted_to_job' where id = quote_id;
+
+  return new_job_id;
+end;
+$$;
+
+-- RLS Policies
+-- Jobs insert policy
+drop policy if exists "Jobs Insert" on jobs;
+create policy "Allow quote converters to insert jobs" on jobs for insert
+  with check (
+    exists (
+      select 1 from user_roles
+      where user_id = auth.uid()
+      and role in ('Sales', 'Manager', 'Admin')
+    )
+  );
+
+-- Job materials insert policy
+alter table job_materials enable row level security;
+drop policy if exists "Job Materials Insert" on job_materials;
+create policy "Allow quote converters to assign job materials" on job_materials for insert
+  with check (
+    exists (
+      select 1 from user_roles
+      where user_id = auth.uid()
+      and role in ('Sales', 'Manager', 'Admin')
+    )
+  );
+
+-- Quotes status update policy for conversion
+create policy "Allow status update to converted_to_job" on quotes for update
+  using (
+    exists (
+      select 1 from user_roles
+      where user_id = auth.uid()
+      and role in ('Sales', 'Manager', 'Admin')
+    )
+  )
+  with check (status = 'converted_to_job');

--- a/installer-app/src/app/quotes/QuotesPage.tsx
+++ b/installer-app/src/app/quotes/QuotesPage.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { SZButton } from "../../components/ui/SZButton";
 import { SZTable } from "../../components/ui/SZTable";
 import QuoteFormModal, {
   QuoteData,
 } from "../../components/modals/QuoteFormModal";
 import useQuotes from "../../lib/hooks/useQuotes";
+import supabase from "../../lib/supabaseClient";
 
 type Toast = { message: string; success: boolean } | null;
 import {
@@ -14,6 +16,7 @@ import {
 } from "../../components/global-states";
 
 const QuotesPage: React.FC = () => {
+  const navigate = useNavigate();
   const [
     quotes,
     {
@@ -74,7 +77,15 @@ const QuotesPage: React.FC = () => {
   };
 
   const convertQuoteToJob = async (id: string) => {
-    console.log('convert quote', id);
+    setToast(null);
+    const { data, error } = await supabase.rpc("convert_quote_to_job", { quote_id: id });
+    if (error) {
+      setToast({ message: "Failed to convert quote: " + error.message, success: false });
+    } else {
+      setToast({ message: "Quote converted to job", success: true });
+      navigate(`/jobs/${data}`);
+    }
+    setTimeout(() => setToast(null), 3000);
   };
 
   return (


### PR DESCRIPTION
## Summary
- add convert_quote_to_job RPC function and policies
- allow converting approved quotes from QuotesPage
- update schema lock

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6858c3f33264832d8ebfd08581961b5b