### PR TITLE
Add calendar drag-and-drop scheduling

### DIFF
--- a/installer-app/api/migrations/034_add_job_scheduled_date.sql
+++ b/installer-app/api/migrations/034_add_job_scheduled_date.sql
@@ -1,0 +1,14 @@
+-- Add scheduled_date column if missing
+alter table jobs
+  add column if not exists scheduled_date timestamptz;
+
+-- Policy allowing only Manager or Admin to update scheduled_date
+create policy "Allow rescheduling by Manager/Admin" on jobs
+  for update
+  using (
+    exists (
+      select 1 from user_roles
+      where user_id = auth.uid() and role in ('Manager', 'Admin')
+    )
+  )
+  with check (true);

--- a/installer-app/src/components/calendar/JobCalendar.tsx
+++ b/installer-app/src/components/calendar/JobCalendar.tsx
@@ -1,12 +1,14 @@
-import React from 'react';
-import { Calendar, dateFnsLocalizer, Views } from 'react-big-calendar';
-import 'react-big-calendar/lib/css/react-big-calendar.css';
-import withDragAndDrop, { withDragAndDropProps } from 'react-big-calendar/lib/addons/dragAndDrop';
-import { format, parse, startOfWeek, getDay } from 'date-fns';
-import enUS from 'date-fns/locale/en-US';
+import React from "react";
+import { Calendar, dateFnsLocalizer, Views } from "react-big-calendar";
+import "react-big-calendar/lib/css/react-big-calendar.css";
+import withDragAndDrop, {
+  withDragAndDropProps,
+} from "react-big-calendar/lib/addons/dragAndDrop";
+import { format, parse, startOfWeek, getDay } from "date-fns";
+import enUS from "date-fns/locale/en-US";
 
 const locales = {
-  'en-US': enUS,
+  "en-US": enUS,
 };
 
 const localizer = dateFnsLocalizer({
@@ -33,28 +35,38 @@ export interface JobCalendarProps {
 }
 
 const statusColors: Record<string, string> = {
-  assigned: '#3b82f6',
-  in_progress: '#f59e0b',
-  needs_qa: '#f97316',
-  complete: '#10b981',
-  rework: '#ef4444',
+  assigned: "#3b82f6",
+  in_progress: "#f59e0b",
+  needs_qa: "#f97316",
+  complete: "#10b981",
+  rework: "#ef4444",
 };
 
-const DnDCalendar = withDragAndDrop(Calendar as React.ComponentType<withDragAndDropProps<JobEvent>>);
+const DnDCalendar = withDragAndDrop(
+  Calendar as React.ComponentType<withDragAndDropProps<JobEvent>>,
+);
 
-export const JobCalendar: React.FC<JobCalendarProps> = ({ events, onEventDrop, editable = true }) => {
+export const JobCalendar: React.FC<JobCalendarProps> = ({
+  events,
+  onEventDrop,
+  editable = true,
+}) => {
   return (
     <DnDCalendar
       localizer={localizer}
       events={events}
       defaultView={Views.WEEK}
-      views={[Views.WEEK, Views.MONTH]}
-      style={{ height: '80vh' }}
-      onEventDrop={({ event, start }) => onEventDrop?.(event as JobEvent, start)}
+      views={[Views.MONTH, Views.WEEK, Views.DAY]}
+      step={30}
+      timeslots={2}
+      style={{ height: "80vh" }}
+      onEventDrop={({ event, start }) =>
+        onEventDrop?.(event as JobEvent, start)
+      }
       resizable={false}
       draggableAccessor={(event) => editable && !!event.assignedTo}
       eventPropGetter={(event) => {
-        const bg = statusColors[event.status] || '#6b7280';
+        const bg = statusColors[event.status] || "#6b7280";
         return { style: { backgroundColor: bg, borderColor: bg } };
       }}
     />

--- a/installer-app/src/routes.ts
+++ b/installer-app/src/routes.ts
@@ -57,7 +57,10 @@ export type RouteConfig = {
 
 export const ROUTES: RouteConfig[] = [
   { path: "/login", element: React.createElement(LoginPage) },
-  { path: "/forgot-password", element: React.createElement(ForgotPasswordPage) },
+  {
+    path: "/forgot-password",
+    element: React.createElement(ForgotPasswordPage),
+  },
   { path: "/reset-password", element: React.createElement(ResetPasswordPage) },
   { path: "/unauthorized", element: React.createElement(Unauthorized) },
   { path: "/select-role", element: React.createElement(RoleSelector) },
@@ -193,7 +196,7 @@ export const ROUTES: RouteConfig[] = [
     label: "Install Manager Dashboard",
   },
   {
-    path: "/install-manager/calendar",
+    path: "/calendar",
     element: React.createElement(CalendarPage),
     role: ["Manager", "Admin"],
     label: "Schedule Calendar",

--- a/schema-lock.sql
+++ b/schema-lock.sql
@@ -468,6 +468,7 @@ CREATE TABLE public.jobs (
     clinic_name text NOT NULL,
     contact_name text NOT NULL,
     contact_phone text NOT NULL,
+    scheduled_date timestamp with time zone,
     assigned_to uuid,
     status text DEFAULT 'created'::text NOT NULL,
     created_at timestamp without time zone DEFAULT now(),
@@ -1267,6 +1268,12 @@ CREATE POLICY "Clients Update" ON public.clients FOR UPDATE USING ((EXISTS ( SEL
 CREATE POLICY "InstallerInventory Insert" ON public.installer_inventory FOR INSERT WITH CHECK (((installer_id = auth.uid()) OR (EXISTS ( SELECT 1
    FROM public.user_roles
   WHERE ((user_roles.user_id = auth.uid()) AND (user_roles.role = ANY (ARRAY['Admin'::text, 'Manager'::text])))))));
+
+-- Name: jobs Allow rescheduling by Manager/Admin; Type: POLICY; Schema: public; Owner: postgres
+
+CREATE POLICY "Allow rescheduling by Manager/Admin" ON public.jobs FOR UPDATE USING ((EXISTS ( SELECT 1
+   FROM public.user_roles
+  WHERE ((user_roles.user_id = auth.uid()) AND (user_roles.role = ANY (ARRAY['Manager'::text, 'Admin'::text])))))) WITH CHECK (true);
 
 
 --


### PR DESCRIPTION
## Summary
- allow jobs to track a `scheduled_date` and add RLS for managers/admins
- expose schedule calendar at `/calendar`
- support drag & drop rescheduling via `react-big-calendar`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858c4a91994832db9e79e790e99df27