### PR TITLE
Implement search + filter UI pattern

### DIFF
--- a/installer-app/src/app/clients/ClientsPage.tsx
+++ b/installer-app/src/app/clients/ClientsPage.tsx
@@ -6,7 +6,9 @@ import ClientFormModal, {
   Client,
 } from "../../components/modals/ClientFormModal";
 import useClients from "../../lib/hooks/useClients";
-import SearchBar from "../../components/ui/search/SearchBar";
+import SearchAndFilterBar, {
+  FilterOption,
+} from "../../components/search/SearchAndFilterBar";
 import FilterPanel, {
   AppliedFilters,
   FilterDefinition,
@@ -32,17 +34,11 @@ const ClientsPage: React.FC = () => {
   };
   const [filters, setFilters] = useState<AppliedFilters>(initialFilters);
 
+  const searchFilterOptions: FilterOption[] = [
+    { key: "status", label: "Status", options: ["active", "inactive"] },
+  ];
+
   const filterDefs: FilterDefinition[] = [
-    {
-      key: "status",
-      label: "Status",
-      type: "dropdown",
-      options: [
-        { label: "All", value: "" },
-        { label: "active", value: "active" },
-        { label: "inactive", value: "inactive" },
-      ],
-    },
     { key: "created", label: "Created Date", type: "dateRange" },
   ];
 
@@ -87,6 +83,11 @@ const ClientsPage: React.FC = () => {
       p.delete("search");
     }
     setParams(p);
+  };
+
+  const handleFilterChange = (key: string, value: string) => {
+    const updated = { ...filters, [key]: value };
+    applyFilters(updated);
   };
 
   const applyFilters = (vals: AppliedFilters) => {
@@ -169,13 +170,12 @@ const ClientsPage: React.FC = () => {
       </div>
 
       <div className="flex flex-wrap items-end gap-4">
-        <div className="flex-1 min-w-[200px]">
-          <SearchBar
-            placeholder="Search clients"
-            onSearch={handleSearch}
-            initialValue={search}
-          />
-        </div>
+        <SearchAndFilterBar
+          searchPlaceholder="Search clients"
+          filters={searchFilterOptions}
+          onSearch={handleSearch}
+          onFilterChange={handleFilterChange}
+        />
         <FilterPanel
           filters={filterDefs}
           onApply={applyFilters}

--- a/installer-app/src/app/crm/LeadsPage.tsx
+++ b/installer-app/src/app/crm/LeadsPage.tsx
@@ -3,6 +3,9 @@ import { useNavigate } from "react-router-dom";
 import { SZTable } from "../../components/ui/SZTable";
 import { SZButton } from "../../components/ui/SZButton";
 import { SZInput } from "../../components/ui/SZInput";
+import SearchAndFilterBar, {
+  FilterOption,
+} from "../../components/search/SearchAndFilterBar";
 import useLeads, { Lead } from "../../lib/hooks/useLeads";
 import LeadHistoryModal from "./LeadHistoryModal";
 
@@ -31,7 +34,8 @@ export default function LeadsPage() {
     address: "",
   });
   const [adding, setAdding] = useState(false);
-  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [statusFilter, setStatusFilter] = useState<string>("");
+  const [search, setSearch] = useState("");
   const [historyLead, setHistoryLead] = useState<Lead | null>(null);
   const [toast, setToast] = useState<Toast>(null);
   const [convertingId, setConvertingId] = useState<string | null>(null);
@@ -63,27 +67,29 @@ export default function LeadsPage() {
     setConvertingId(null);
   };
 
-  const filteredLeads =
-    statusFilter === "all" ? leads : leads.filter((l) => l.status === statusFilter);
+  const filteredLeads = leads.filter((l) => {
+    if (statusFilter && l.status !== statusFilter) return false;
+    if (search.trim()) {
+      const term = search.toLowerCase();
+      const combined = `${l.clinic_name} ${l.contact_name} ${l.contact_email} ${l.contact_phone}`.toLowerCase();
+      if (!combined.includes(term)) return false;
+    }
+    return true;
+  });
+
+  const searchFilterOptions: FilterOption[] = [
+    { key: "status", label: "Status", options: statuses },
+  ];
 
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Leads</h1>
-      <div>
-        <label className="mr-2 text-sm font-medium">Filter by status:</label>
-        <select
-          className="border rounded px-2 py-1"
-          value={statusFilter}
-          onChange={(e) => setStatusFilter(e.target.value)}
-        >
-          <option value="all">All</option>
-          {statuses.map((s) => (
-            <option key={s} value={s}>
-              {s}
-            </option>
-          ))}
-        </select>
-      </div>
+      <SearchAndFilterBar
+        searchPlaceholder="Search leads"
+        filters={searchFilterOptions}
+        onSearch={setSearch}
+        onFilterChange={(k, v) => setStatusFilter(v)}
+      />
       <div className="grid md:grid-cols-5 gap-2">
         <SZInput id="clinic" label="Clinic" value={form.clinic_name} onChange={(v) => setForm({ ...form, clinic_name: v })} />
         <SZInput id="contact" label="Contact" value={form.contact_name} onChange={(v) => setForm({ ...form, contact_name: v })} />

--- a/installer-app/src/app/quotes/QuotesPage.tsx
+++ b/installer-app/src/app/quotes/QuotesPage.tsx
@@ -2,6 +2,9 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { SZButton } from "../../components/ui/SZButton";
 import { SZTable } from "../../components/ui/SZTable";
+import SearchAndFilterBar, {
+  FilterOption,
+} from "../../components/search/SearchAndFilterBar";
 import QuoteFormModal, {
   QuoteData,
 } from "../../components/modals/QuoteFormModal";
@@ -14,6 +17,8 @@ import {
   GlobalEmpty,
   GlobalError,
 } from "../../components/global-states";
+
+const statuses = ["draft", "pending", "approved"];
 
 const QuotesPage: React.FC = () => {
   const navigate = useNavigate();
@@ -35,6 +40,8 @@ const QuotesPage: React.FC = () => {
   const [open, setOpen] = useState(false);
   const [toast, setToast] = useState<Toast>(null);
   const [approvingId, setApprovingId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<string>("");
 
   const handleSave = async (data: QuoteData) => {
     if (data.id) {
@@ -88,6 +95,19 @@ const QuotesPage: React.FC = () => {
     setTimeout(() => setToast(null), 3000);
   };
 
+  const searchFilterOptions: FilterOption[] = [
+    { key: "status", label: "Status", options: statuses },
+  ];
+
+  const filteredQuotes = quotes.filter((q) => {
+    if (statusFilter && q.status !== statusFilter) return false;
+    if (search.trim()) {
+      const term = search.toLowerCase();
+      if (!(q.client_name ?? "").toLowerCase().includes(term)) return false;
+    }
+    return true;
+  });
+
   return (
     <div className="p-4 space-y-4">
       <div className="flex justify-between items-center">
@@ -102,6 +122,12 @@ const QuotesPage: React.FC = () => {
           New Quote
         </SZButton>
       </div>
+      <SearchAndFilterBar
+        searchPlaceholder="Search quotes"
+        filters={searchFilterOptions}
+        onSearch={setSearch}
+        onFilterChange={(k, v) => setStatusFilter(v)}
+      />
       {loading && <GlobalLoading />}
       {error && <GlobalError message={error} onRetry={fetchQuotes} />}
       {!loading && !error && quotes.length === 0 && (
@@ -118,9 +144,12 @@ const QuotesPage: React.FC = () => {
           </SZButton>
         </div>
       )}
-      {!loading && !error && quotes.length > 0 && (
+      {!loading && !error && quotes.length > 0 && filteredQuotes.length === 0 && (
+        <GlobalEmpty message="No Quotes Found" />
+      )}
+      {!loading && !error && quotes.length > 0 && filteredQuotes.length > 0 && (
         <SZTable headers={["Client", "Total", "Status", "Actions"]}>
-          {quotes.map((q) => (
+          {filteredQuotes.map((q) => (
             <tr key={q.id} className="border-t">
               <td className="p-2 border">{q.client_name}</td>
               <td className="p-2 border">${(q.total ?? 0).toFixed(2)}</td>

--- a/installer-app/src/components/search/SearchAndFilterBar.tsx
+++ b/installer-app/src/components/search/SearchAndFilterBar.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from "react";
+
+export type FilterOption = {
+  key: string;
+  label: string;
+  options: string[];
+};
+
+export interface Props {
+  searchPlaceholder?: string;
+  filters?: FilterOption[];
+  onSearch: (query: string) => void;
+  onFilterChange: (key: string, value: string) => void;
+}
+
+export const SearchAndFilterBar: React.FC<Props> = ({
+  searchPlaceholder = "Search...",
+  filters = [],
+  onSearch,
+  onFilterChange,
+}) => {
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      onSearch(query.trim());
+    }, 500);
+    return () => clearTimeout(id);
+  }, [query, onSearch]);
+
+  const handleFilter = (key: string, value: string) => {
+    setSelected((s) => ({ ...s, [key]: value }));
+    onFilterChange(key, value);
+  };
+
+  return (
+    <div className="flex flex-wrap items-end gap-2">
+      <div className="flex-1 min-w-[200px]">
+        <div className="relative">
+          <input
+            type="text"
+            placeholder={searchPlaceholder}
+            className="w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-green-500"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          {query && (
+            <button
+              aria-label="Clear search"
+              onClick={() => setQuery("")}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400"
+            >
+              ×
+            </button>
+          )}
+        </div>
+      </div>
+      {filters.map((f) => (
+        <div key={f.key}>
+          <label className="block text-sm font-medium text-gray-700">
+            {f.label}
+          </label>
+          <select
+            className="border rounded px-3 py-2"
+            value={selected[f.key] ?? ""}
+            onChange={(e) => handleFilter(f.key, e.target.value)}
+          >
+            <option value="">All</option>
+            {f.options.map((o) => (
+              <option key={o} value={o}>
+                {o}
+              </option>
+            ))}
+          </select>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default SearchAndFilterBar;


### PR DESCRIPTION
## Summary
- add `SearchAndFilterBar` reusable component
- integrate search and filter bar in Clients, Leads and Quotes pages

## Testing
- `npm test --silent` *(fails: Uncaught [Error: useAuth must be used within an AuthProvider])*

------
https://chatgpt.com/codex/tasks/task_e_6858c8a94080832dbcfe82ae81242b13