### PR TITLE
Add revenue dashboard and SQL view

### DIFF
--- a/installer-app/api/migrations/V5_create_revenue_by_month_view.sql
+++ b/installer-app/api/migrations/V5_create_revenue_by_month_view.sql
@@ -1,0 +1,23 @@
+create or replace view revenue_by_month as
+select
+  date_trunc('month', invoice_date) as month,
+  sum(total_due) as total_invoiced,
+  sum(coalesce(p.amount, 0)) as total_paid,
+  sum(total_due) - sum(coalesce(p.amount, 0)) as outstanding_balance
+from invoices i
+left join payments p on p.invoice_id = i.id
+group by month
+order by month desc;
+
+alter view revenue_by_month enable row level security;
+
+create policy "Allow finance/admin to view revenue"
+on revenue_by_month
+for select
+using (
+  exists (
+    select 1 from user_roles
+    where user_id = auth.uid()
+    and role in ('Admin', 'Manager', 'Finance')
+  )
+);

--- a/installer-app/package-lock.json
+++ b/installer-app/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.50.0",
+        "chart.js": "^4.4.1",
         "date-fns": "^4.1.0",
         "react": "^18.2.0",
         "react-big-calendar": "^1.19.4",
+        "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^5.5.0",
         "react-router-dom": "^6.23.0"
@@ -4092,6 +4094,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@mdx-js/react": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.0.tgz",
@@ -6517,6 +6525,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -13251,6 +13271,16 @@
       "peerDependencies": {
         "react": "^16.14.0 || ^17 || ^18 || ^19",
         "react-dom": "^16.14.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-docgen": {

--- a/installer-app/package.json
+++ b/installer-app/package.json
@@ -18,7 +18,9 @@
     "react-big-calendar": "^1.19.4",
     "react-dom": "^18.2.0",
     "react-icons": "^5.5.0",
-    "react-router-dom": "^6.23.0"
+    "react-router-dom": "^6.23.0",
+    "chart.js": "^4.4.1",
+    "react-chartjs-2": "^5.2.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.27.2",

--- a/installer-app/src/app/reports/RevenueDashboardPage.tsx
+++ b/installer-app/src/app/reports/RevenueDashboardPage.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import useRevenueByMonth from '../../lib/hooks/useRevenueByMonth';
+import { SZTable } from '../../components/ui/SZTable';
+import { Bar } from 'react-chartjs-2';
+import 'chart.js/auto';
+
+const RevenueDashboardPage: React.FC = () => {
+  const rows = useRevenueByMonth();
+
+  const chartData = {
+    labels: rows.map((r) =>
+      new Date(r.month).toLocaleDateString(undefined, {
+        month: 'short',
+        year: 'numeric',
+      }),
+    ),
+    datasets: [
+      {
+        label: 'Invoiced',
+        data: rows.map((r) => r.total_invoiced),
+        backgroundColor: '#60a5fa',
+      },
+      {
+        label: 'Paid',
+        data: rows.map((r) => r.total_paid),
+        backgroundColor: '#34d399',
+      },
+    ],
+  };
+
+  const current = rows[0];
+  const previous = rows[1];
+  const currentRevenue = current?.total_paid ?? 0;
+  const prevRevenue = previous?.total_paid ?? 0;
+  const outstanding = current?.outstanding_balance ?? 0;
+  const change = prevRevenue
+    ? ((currentRevenue - prevRevenue) / prevRevenue) * 100
+    : 0;
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Revenue Dashboard</h1>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="bg-white shadow rounded p-4">
+          <p className="text-sm text-gray-600">This Month Revenue</p>
+          <p className="text-lg font-semibold">
+            ${currentRevenue.toFixed(2)}
+          </p>
+          {previous && (
+            <p className="text-sm text-gray-500">
+              {change >= 0 ? '+' : ''}{change.toFixed(1)}% vs last month
+            </p>
+          )}
+        </div>
+        <div className="bg-white shadow rounded p-4">
+          <p className="text-sm text-gray-600">Outstanding AR</p>
+          <p className="text-lg font-semibold">${outstanding.toFixed(2)}</p>
+        </div>
+      </div>
+      <div className="bg-white p-4 rounded shadow">
+        <Bar data={chartData} />
+      </div>
+      <SZTable headers={[
+        'Month',
+        'Invoiced',
+        'Paid',
+        'Outstanding',
+      ]}>
+        {rows.map((r) => (
+          <tr key={r.month} className="border-t">
+            <td className="p-2 border">
+              {new Date(r.month).toLocaleDateString(undefined, {
+                month: 'short',
+                year: 'numeric',
+              })}
+            </td>
+            <td className="p-2 border text-right">
+              ${r.total_invoiced.toFixed(2)}
+            </td>
+            <td className="p-2 border text-right">
+              ${r.total_paid.toFixed(2)}
+            </td>
+            <td className="p-2 border text-right">
+              ${r.outstanding_balance.toFixed(2)}
+            </td>
+          </tr>
+        ))}
+      </SZTable>
+    </div>
+  );
+};
+
+export default RevenueDashboardPage;

--- a/installer-app/src/lib/hooks/useRevenueByMonth.ts
+++ b/installer-app/src/lib/hooks/useRevenueByMonth.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+import supabase from '../supabaseClient';
+
+export interface RevenueMonth {
+  month: string;
+  total_invoiced: number;
+  total_paid: number;
+  outstanding_balance: number;
+}
+
+export default function useRevenueByMonth() {
+  const [data, setData] = useState<RevenueMonth[]>([]);
+
+  useEffect(() => {
+    supabase
+      .from('revenue_by_month')
+      .select('*')
+      .then((res) => {
+        if (res.error) {
+          console.error(res.error);
+          setData([]);
+        } else {
+          setData(res.data as RevenueMonth[]);
+        }
+      });
+  }, []);
+
+  return data;
+}

--- a/installer-app/src/routes.ts
+++ b/installer-app/src/routes.ts
@@ -38,6 +38,7 @@ import TimeTrackingPanel from "./app/time-tracking/TimeTrackingPanel";
 import ReportsPage from "./app/reports/ReportsPage";
 import TechnicianPayReportPage from "./app/reports/TechnicianPayReportPage";
 import InvoiceAgingPage from "./app/reports/InvoiceAgingPage";
+import RevenueDashboardPage from "./app/reports/RevenueDashboardPage";
 import LeadsPage from "./app/crm/LeadsPage";
 import PaymentReportPage from "./app/admin/reports/payments/PaymentReportPage";
 import InventoryAlertsPage from "./app/admin/InventoryAlertsPage";
@@ -290,6 +291,12 @@ export const ROUTES: RouteConfig[] = [
     path: "/reports/invoice-aging",
     element: React.createElement(InvoiceAgingPage),
     role: ["Manager", "Admin"],
+  },
+  {
+    path: "/reports/revenue",
+    element: React.createElement(RevenueDashboardPage),
+    role: ["Admin", "Manager", "Finance"],
+    label: "Revenue",
   },
   {
     path: "/admin/reports/payments",


### PR DESCRIPTION
## Summary
- create `revenue_by_month` view with RLS
- add RevenueDashboardPage with chart and table
- expose hook `useRevenueByMonth`
- register route `/reports/revenue`
- add chart.js dependencies

## Testing
- `npm test` *(fails: 1 failed, 13 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6858c8d57c0c832d99f8490844e0116b