### PR TITLE
Implement role-based onboarding panel

### DIFF
--- a/installer-app/api/migrations/035_create_user_onboarding_status.sql
+++ b/installer-app/api/migrations/035_create_user_onboarding_status.sql
@@ -1,0 +1,20 @@
+create table if not exists user_onboarding_status (
+  user_id uuid primary key references auth.users(id),
+  installer_started_job boolean default false,
+  sales_created_quote boolean default false,
+  manager_reviewed_job boolean default false,
+  admin_invited_user boolean default false,
+  dismissed boolean default false,
+  updated_at timestamptz default now()
+);
+
+alter table user_onboarding_status enable row level security;
+
+create policy "Allow user to update their onboarding status"
+  on user_onboarding_status for update
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "Allow user to read their onboarding status"
+  on user_onboarding_status for select
+  using (auth.uid() = user_id);

--- a/installer-app/src/app/admin/AdminDashboard.jsx
+++ b/installer-app/src/app/admin/AdminDashboard.jsx
@@ -12,7 +12,7 @@ export default function AdminDashboard() {
 
   return (
     <div className="p-4 space-y-4">
-      <OnboardingPanel role={role} userId={user?.id ?? null} />
+      <OnboardingPanel role={role} userId={user?.id || ""} />
       <InventoryAlertBanner />
       <h1 className="text-2xl font-bold">Business KPIs</h1>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">

--- a/installer-app/src/app/admin/users/AdminInviteUserPage.tsx
+++ b/installer-app/src/app/admin/users/AdminInviteUserPage.tsx
@@ -20,7 +20,7 @@ const AdminInviteUserPage: React.FC = () => {
   const [role, setRole] = useState("Installer");
   const [loading, setLoading] = useState(false);
   const [toast, setToast] = useState<Toast>(null);
-  const { refreshRoles } = useAuth();
+  const { refreshRoles, user } = useAuth();
 
   const submitInvite = async () => {
     setLoading(true);
@@ -29,9 +29,13 @@ const AdminInviteUserPage: React.FC = () => {
     if (error) {
       setToast({ message: error.message, success: false });
     } else if (data?.user) {
-      await supabase
-        .from("user_roles")
-        .insert({ user_id: data.user.id, role });
+      await supabase.from("user_roles").insert({ user_id: data.user.id, role });
+      if (user?.id) {
+        const { default: update } = await import(
+          "../../../lib/updateUserOnboarding"
+        );
+        await update(user.id, "admin_invited_user");
+      }
       await refreshRoles();
       setToast({ message: `Invite sent to ${email}`, success: true });
       setEmail("");
@@ -44,9 +48,17 @@ const AdminInviteUserPage: React.FC = () => {
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Invite User</h1>
-      <SZInput id="invite_email" label="Email" value={email} onChange={setEmail} />
+      <SZInput
+        id="invite_email"
+        label="Email"
+        value={email}
+        onChange={setEmail}
+      />
       <div className="space-y-1">
-        <label htmlFor="invite_role" className="block text-sm font-medium text-gray-700">
+        <label
+          htmlFor="invite_role"
+          className="block text-sm font-medium text-gray-700"
+        >
           Role
         </label>
         <select

--- a/installer-app/src/app/install-manager/page.jsx
+++ b/installer-app/src/app/install-manager/page.jsx
@@ -42,7 +42,7 @@ export default function InstallManagerDashboard() {
           New Job
         </SZButton>
       </header>
-      <OnboardingPanel role={role} userId={user?.id ?? null} />
+      <OnboardingPanel role={role} userId={user?.id || ""} />
       <InventoryAlertBanner />
       {loading && <GlobalLoading />}
       {error && <GlobalError message={error} onRetry={refresh} />}

--- a/installer-app/src/app/install-manager/quotes/QuoteBuilderPage.tsx
+++ b/installer-app/src/app/install-manager/quotes/QuoteBuilderPage.tsx
@@ -1,22 +1,22 @@
-import React, { useState, useEffect } from 'react';
-import supabase from '../../../lib/supabaseClient';
-import { useAuth } from '../../../lib/hooks/useAuth';
+import React, { useState, useEffect } from "react";
+import supabase from "../../../lib/supabaseClient";
+import { useAuth } from "../../../lib/hooks/useAuth";
 
 export default function QuoteBuilderPage() {
   const { user, role } = useAuth();
   const [clients, setClients] = useState([]);
-  const [selectedClient, setSelectedClient] = useState('');
-  const [title, setTitle] = useState('');
+  const [selectedClient, setSelectedClient] = useState("");
+  const [title, setTitle] = useState("");
   const [lineItems, setLineItems] = useState([
-    { description: '', quantity: 1, unit_price: 0 }
+    { description: "", quantity: 1, unit_price: 0 },
   ]);
-  const [status, setStatus] = useState('draft');
-  const [notes, setNotes] = useState('');
+  const [status, setStatus] = useState("draft");
+  const [notes, setNotes] = useState("");
   const [taxRate, setTaxRate] = useState(0);
 
   useEffect(() => {
     async function fetchClients() {
-      const { data } = await supabase.from('clients').select('id, name');
+      const { data } = await supabase.from("clients").select("id, name");
       setClients(data || []);
     }
     fetchClients();
@@ -29,42 +29,53 @@ export default function QuoteBuilderPage() {
     setLineItems(updatedItems);
   };
 
-  const addLineItem = () => setLineItems([...lineItems, { description: '', quantity: 1, unit_price: 0 }]);
+  const addLineItem = () =>
+    setLineItems([
+      ...lineItems,
+      { description: "", quantity: 1, unit_price: 0 },
+    ]);
   const removeLineItem = (index) => {
     const updated = lineItems.filter((_, i) => i !== index);
     setLineItems(updated);
   };
 
-  const total = lineItems.reduce((sum, item) => sum + (item.quantity * item.unit_price), 0);
-  const totalWithTax = total + (total * taxRate / 100);
+  const total = lineItems.reduce(
+    (sum, item) => sum + item.quantity * item.unit_price,
+    0,
+  );
+  const totalWithTax = total + (total * taxRate) / 100;
 
   const handleSave = async (send = false) => {
     const { data: quote, error } = await supabase
-      .from('quotes')
+      .from("quotes")
       .insert({
         client_id: selectedClient,
         created_by: user.id,
         title,
-        status: send ? 'sent' : 'draft'
+        status: send ? "sent" : "draft",
       })
       .select()
       .single();
 
-    if (!quote) return alert('Failed to create quote.');
+    if (!quote) return alert("Failed to create quote.");
+    const { default: update } = await import(
+      "../../../lib/updateUserOnboarding"
+    );
+    await update(user.id, "sales_created_quote");
 
-    const itemsPayload = lineItems.map(item => ({
+    const itemsPayload = lineItems.map((item) => ({
       quote_id: quote.id,
       description: item.description,
       quantity: item.quantity,
       unit_price: item.unit_price,
-      total: item.quantity * item.unit_price
+      total: item.quantity * item.unit_price,
     }));
 
-    await supabase.from('quote_items').insert(itemsPayload);
-    alert(`Quote ${send ? 'sent' : 'saved'} successfully.`);
+    await supabase.from("quote_items").insert(itemsPayload);
+    alert(`Quote ${send ? "sent" : "saved"} successfully.`);
   };
 
-  if (role !== 'Install Manager') {
+  if (role !== "Install Manager") {
     return <div className="p-4 text-red-600">Access denied.</div>;
   }
 
@@ -73,36 +84,104 @@ export default function QuoteBuilderPage() {
       <h1 className="text-xl font-bold">Create Quote</h1>
       <div className="space-y-2">
         <label>Client</label>
-        <select value={selectedClient} onChange={e => setSelectedClient(e.target.value)} className="border p-2 w-full">
+        <select
+          value={selectedClient}
+          onChange={(e) => setSelectedClient(e.target.value)}
+          className="border p-2 w-full"
+        >
           <option value="">Select a client</option>
-          {clients.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
+          {clients.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
         </select>
       </div>
-      <input value={title} onChange={e => setTitle(e.target.value)} placeholder="Quote Title" className="border p-2 w-full" />
+      <input
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Quote Title"
+        className="border p-2 w-full"
+      />
       <div className="space-y-2">
         <h2 className="font-semibold">Line Items</h2>
         {lineItems.map((item, idx) => (
           <div key={idx} className="flex gap-2">
-            <input value={item.description} onChange={e => handleLineItemChange(idx, 'description', e.target.value)} placeholder="Description" className="border p-1 flex-1" />
-            <input type="number" value={item.quantity} onChange={e => handleLineItemChange(idx, 'quantity', parseFloat(e.target.value))} className="border p-1 w-24" />
-            <input type="number" value={item.unit_price} onChange={e => handleLineItemChange(idx, 'unit_price', parseFloat(e.target.value))} className="border p-1 w-24" />
-            <button onClick={() => removeLineItem(idx)} className="text-red-500">✕</button>
+            <input
+              value={item.description}
+              onChange={(e) =>
+                handleLineItemChange(idx, "description", e.target.value)
+              }
+              placeholder="Description"
+              className="border p-1 flex-1"
+            />
+            <input
+              type="number"
+              value={item.quantity}
+              onChange={(e) =>
+                handleLineItemChange(
+                  idx,
+                  "quantity",
+                  parseFloat(e.target.value),
+                )
+              }
+              className="border p-1 w-24"
+            />
+            <input
+              type="number"
+              value={item.unit_price}
+              onChange={(e) =>
+                handleLineItemChange(
+                  idx,
+                  "unit_price",
+                  parseFloat(e.target.value),
+                )
+              }
+              className="border p-1 w-24"
+            />
+            <button
+              onClick={() => removeLineItem(idx)}
+              className="text-red-500"
+            >
+              ✕
+            </button>
           </div>
         ))}
-        <button onClick={addLineItem} className="text-blue-600 underline">Add Line Item</button>
+        <button onClick={addLineItem} className="text-blue-600 underline">
+          Add Line Item
+        </button>
       </div>
       <div>
         <label>Tax Rate (%)</label>
-        <input type="number" value={taxRate} onChange={e => setTaxRate(parseFloat(e.target.value))} className="border p-1 w-24" />
+        <input
+          type="number"
+          value={taxRate}
+          onChange={(e) => setTaxRate(parseFloat(e.target.value))}
+          className="border p-1 w-24"
+        />
       </div>
       <div>
         <label>Notes</label>
-        <textarea value={notes} onChange={e => setNotes(e.target.value)} className="border p-2 w-full" />
+        <textarea
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="border p-2 w-full"
+        />
       </div>
       <div className="font-semibold">Total: ${totalWithTax.toFixed(2)}</div>
       <div className="flex gap-4">
-        <button onClick={() => handleSave(false)} className="bg-gray-200 px-4 py-2">Save Draft</button>
-        <button onClick={() => handleSave(true)} className="bg-blue-600 text-white px-4 py-2">Send Quote</button>
+        <button
+          onClick={() => handleSave(false)}
+          className="bg-gray-200 px-4 py-2"
+        >
+          Save Draft
+        </button>
+        <button
+          onClick={() => handleSave(true)}
+          className="bg-blue-600 text-white px-4 py-2"
+        >
+          Send Quote
+        </button>
       </div>
     </div>
   );

--- a/installer-app/src/app/installer/InstallerDashboard.tsx
+++ b/installer-app/src/app/installer/InstallerDashboard.tsx
@@ -18,7 +18,7 @@ const InstallerDashboard: React.FC = () => {
 
   return (
     <div className="p-4 space-y-4">
-      <OnboardingPanel role={role} userId={user?.id ?? null} />
+      <OnboardingPanel role={role as any} userId={user?.id || ""} />
       <h1 className="text-2xl font-bold">Assigned Jobs</h1>
       <ul className="space-y-2">
         {myJobs.map((j) => (

--- a/installer-app/src/app/installer/jobs/InstallerJobPage.tsx
+++ b/installer-app/src/app/installer/jobs/InstallerJobPage.tsx
@@ -110,6 +110,12 @@ const InstallerJobPage: React.FC = () => {
       .from("jobs")
       .update({ status: "in_progress" })
       .eq("id", job.id);
+    if (session?.user?.id) {
+      const { default: update } = await import(
+        "../../../lib/updateUserOnboarding"
+      );
+      await update(session.user.id, "installer_started_job");
+    }
     refresh();
   };
 

--- a/installer-app/src/app/manager/QAReviewPanel.tsx
+++ b/installer-app/src/app/manager/QAReviewPanel.tsx
@@ -50,6 +50,8 @@ const QAReviewPanel: React.FC = () => {
       decision,
       notes: note,
     });
+    const { default: update } = await import("../../lib/updateUserOnboarding");
+    await update(reviewerId, "manager_reviewed_job");
 
     if (decision === "approved") {
       const { error } = await supabase
@@ -100,7 +102,12 @@ const QAReviewPanel: React.FC = () => {
                 />
               </td>
               <td className="p-2 border space-x-2">
-                <SZButton size="sm" onClick={() => handleDecision(job.id, "approved")}>Approve</SZButton>
+                <SZButton
+                  size="sm"
+                  onClick={() => handleDecision(job.id, "approved")}
+                >
+                  Approve
+                </SZButton>
                 <SZButton
                   size="sm"
                   variant="secondary"

--- a/installer-app/src/app/sales/QuoteBuilderPage.jsx
+++ b/installer-app/src/app/sales/QuoteBuilderPage.jsx
@@ -1,67 +1,127 @@
-import React, { useState, useEffect } from 'react';
-import useAuth from '../../lib/hooks/useAuth';
-import useClients from '../../lib/hooks/useClients';
-import supabase from '../../lib/supabaseClient';
-import { SZInput } from '../../components/ui/SZInput';
-import { SZButton } from '../../components/ui/SZButton';
+import React, { useState, useEffect } from "react";
+import useAuth from "../../lib/hooks/useAuth";
+import useClients from "../../lib/hooks/useClients";
+import supabase from "../../lib/supabaseClient";
+import { SZInput } from "../../components/ui/SZInput";
+import { SZButton } from "../../components/ui/SZButton";
 
 export default function QuoteBuilderPage() {
   const { role, user } = useAuth();
   const [clients] = useClients();
-  const [clientId, setClientId] = useState('');
-  const [items, setItems] = useState([{ description: '', quantity: 1, unit_price: 0 }]);
+  const [clientId, setClientId] = useState("");
+  const [items, setItems] = useState([
+    { description: "", quantity: 1, unit_price: 0 },
+  ]);
   const [tax, setTax] = useState(0);
 
   useEffect(() => {
     if (clients.length && !clientId) setClientId(clients[0].id);
   }, [clients, clientId]);
 
-  if (role !== 'Sales' && role !== 'Admin') return <div className="p-4">Access denied</div>;
+  if (role !== "Sales" && role !== "Admin")
+    return <div className="p-4">Access denied</div>;
 
   const updateItem = (idx, key, value) => {
-    setItems(list => list.map((it, i) => (i === idx ? { ...it, [key]: value } : it)));
+    setItems((list) =>
+      list.map((it, i) => (i === idx ? { ...it, [key]: value } : it)),
+    );
   };
 
-  const addItem = () => setItems(i => [...i, { description: '', quantity: 1, unit_price: 0 }]);
-  const removeItem = idx => setItems(i => i.filter((_, n) => n !== idx));
+  const addItem = () =>
+    setItems((i) => [...i, { description: "", quantity: 1, unit_price: 0 }]);
+  const removeItem = (idx) => setItems((i) => i.filter((_, n) => n !== idx));
 
   const total = items.reduce((s, it) => s + it.quantity * it.unit_price, 0);
   const totalWithTax = total + total * (tax / 100);
 
   const saveQuote = async (send = false) => {
     const { data: quote } = await supabase
-      .from('quotes')
-      .insert({ client_id: clientId, status: send ? 'sent' : 'draft', created_by: user?.id })
+      .from("quotes")
+      .insert({
+        client_id: clientId,
+        status: send ? "sent" : "draft",
+        created_by: user?.id,
+      })
       .select()
       .single();
     if (!quote) return;
-    const rows = items.map(i => ({ ...i, quote_id: quote.id, total: i.quantity * i.unit_price }));
-    if (rows.length) await supabase.from('quote_items').insert(rows);
-    alert(`Quote ${send ? 'sent' : 'saved'}!`);
+    if (user?.id) {
+      const { default: update } = await import(
+        "../../lib/updateUserOnboarding"
+      );
+      await update(user.id, "sales_created_quote");
+    }
+    const rows = items.map((i) => ({
+      ...i,
+      quote_id: quote.id,
+      total: i.quantity * i.unit_price,
+    }));
+    if (rows.length) await supabase.from("quote_items").insert(rows);
+    alert(`Quote ${send ? "sent" : "saved"}!`);
   };
 
   return (
     <div className="p-6 space-y-4 max-w-3xl mx-auto">
       <h1 className="text-2xl font-bold">Create Quote</h1>
       <div>
-        <label className="block text-sm font-medium" htmlFor="client">Client</label>
-        <select id="client" className="border p-2 rounded w-full" value={clientId} onChange={e => setClientId(e.target.value)}>
-          {clients.map(c => (
-            <option key={c.id} value={c.id}>{c.name}</option>
+        <label className="block text-sm font-medium" htmlFor="client">
+          Client
+        </label>
+        <select
+          id="client"
+          className="border p-2 rounded w-full"
+          value={clientId}
+          onChange={(e) => setClientId(e.target.value)}
+        >
+          {clients.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
           ))}
         </select>
       </div>
       {items.map((it, idx) => (
         <div key={idx} className="grid grid-cols-3 gap-2 items-end">
-          <SZInput id={`desc_${idx}`} label="Description" value={it.description} onChange={v => updateItem(idx, 'description', v)} />
-          <SZInput id={`qty_${idx}`} label="Qty" type="number" value={String(it.quantity)} onChange={v => updateItem(idx, 'quantity', parseInt(v))} />
-          <SZInput id={`price_${idx}`} label="Unit Price" type="number" value={String(it.unit_price)} onChange={v => updateItem(idx, 'unit_price', parseFloat(v))} />
-          <SZButton size="sm" variant="destructive" onClick={() => removeItem(idx)}>Remove</SZButton>
+          <SZInput
+            id={`desc_${idx}`}
+            label="Description"
+            value={it.description}
+            onChange={(v) => updateItem(idx, "description", v)}
+          />
+          <SZInput
+            id={`qty_${idx}`}
+            label="Qty"
+            type="number"
+            value={String(it.quantity)}
+            onChange={(v) => updateItem(idx, "quantity", parseInt(v))}
+          />
+          <SZInput
+            id={`price_${idx}`}
+            label="Unit Price"
+            type="number"
+            value={String(it.unit_price)}
+            onChange={(v) => updateItem(idx, "unit_price", parseFloat(v))}
+          />
+          <SZButton
+            size="sm"
+            variant="destructive"
+            onClick={() => removeItem(idx)}
+          >
+            Remove
+          </SZButton>
         </div>
       ))}
-      <SZButton size="sm" variant="secondary" onClick={addItem}>Add Line</SZButton>
+      <SZButton size="sm" variant="secondary" onClick={addItem}>
+        Add Line
+      </SZButton>
       <div>
-        <SZInput id="tax" label="Tax %" type="number" value={String(tax)} onChange={setTax} />
+        <SZInput
+          id="tax"
+          label="Tax %"
+          type="number"
+          value={String(tax)}
+          onChange={setTax}
+        />
       </div>
       <div className="font-semibold">Total: ${totalWithTax.toFixed(2)}</div>
       <div className="flex gap-2">

--- a/installer-app/src/app/sales/SalesDashboard.tsx
+++ b/installer-app/src/app/sales/SalesDashboard.tsx
@@ -6,7 +6,7 @@ const SalesDashboard: React.FC = () => {
   const { role, user } = useAuth();
   return (
     <div className="p-4 space-y-4">
-      <OnboardingPanel role={role} userId={user?.id ?? null} />
+      <OnboardingPanel role={role as any} userId={user?.id || ""} />
       <h1 className="text-2xl font-bold">Sales Dashboard</h1>
       <p>Welcome to the sales dashboard.</p>
     </div>

--- a/installer-app/src/components/onboarding/OnboardingPanel.tsx
+++ b/installer-app/src/components/onboarding/OnboardingPanel.tsx
@@ -1,47 +1,31 @@
-import React from 'react';
-import { useAuth } from '../../lib/hooks/useAuth';
-import useOnboardingState from '../../lib/hooks/useOnboardingState';
+import React from "react";
+import { useAuth } from "../../lib/hooks/useAuth";
+import useOnboardingState from "../../lib/hooks/useOnboardingState";
 
-const TASKS_BY_ROLE: Record<string, { id: string; label: string; link: string }[]> = {
-  Admin: [
-    { id: 'setup_company', label: 'Set up Company Profile', link: '/settings' },
-    { id: 'add_team_member', label: 'Add Your First Team Member', link: '/admin/users' },
-    { id: 'define_services', label: 'Define Service Types', link: '/admin/catalog' },
-    { id: 'review_kpis', label: "Review Today's KPIs", link: '/admin/dashboard' },
-  ],
-  Sales: [
-    { id: 'add_lead', label: 'Add Your First Lead', link: '/crm/leads' },
-    { id: 'create_quote', label: 'Create Your First Quote', link: '/quotes' },
-    { id: 'explore_crm', label: 'Explore the CRM Pipeline', link: '/crm/leads' },
-  ],
-  Manager: [
-    { id: 'review_jobs', label: 'Review Jobs in Progress', link: '/install-manager' },
-    { id: 'approve_quotes', label: 'Approve Pending Quotes', link: '/quotes' },
-    { id: 'payroll_report', label: 'Generate Payroll Report', link: '/reports/technician-pay' },
-  ],
-  Installer: [
-    { id: 'view_jobs', label: 'View Your Assigned Jobs', link: '/installer' },
-    { id: 'complete_test_job', label: 'Complete First Job (Test)', link: '/installer/jobs/mock' },
-    { id: 'log_materials', label: 'Log Materials for a Job', link: '/installer/inventory' },
-  ],
+const TASKS_BY_ROLE: Record<string, { id: string; label: string }[]> = {
+  Admin: [{ id: "admin_invited_user", label: "Invite a User" }],
+  Sales: [{ id: "sales_created_quote", label: "Create a Quote" }],
+  Manager: [{ id: "manager_reviewed_job", label: "Review a Job" }],
+  Installer: [{ id: "installer_started_job", label: "Start a Job" }],
 };
 
 interface Props {
-  role: string | null;
-  userId: string | null;
+  role: "Installer" | "Sales" | "Manager" | "Admin";
+  userId: string;
 }
 
 const OnboardingPanel: React.FC<Props> = ({ role, userId }) => {
   const { user } = useAuth();
-  const { completedTasks, dismissed, completeTask, dismiss } = useOnboardingState(userId);
+  const { completedTasks, dismissed, completeTask, dismiss } =
+    useOnboardingState(userId);
 
-  if (!role || !userId) return null;
+  if (!userId) return null;
   const tasks = TASKS_BY_ROLE[role] || [];
   const allDone = tasks.every((t) => completedTasks.includes(t.id));
 
   if (dismissed || allDone || tasks.length === 0) return null;
 
-  const name = user?.full_name?.split(' ')[0] || 'User';
+  const name = user?.full_name?.split(" ")[0] || "User";
   return (
     <div className="p-4 mb-4 border rounded bg-yellow-50">
       <div className="flex justify-between mb-2">
@@ -49,7 +33,9 @@ const OnboardingPanel: React.FC<Props> = ({ role, userId }) => {
           <h2 className="font-semibold">{`Welcome, ${name}! Let's get you set up as a ${role}.`}</h2>
           <p className="text-sm text-gray-600">{`${completedTasks.length} of ${tasks.length} tasks completed`}</p>
         </div>
-        <button onClick={dismiss} className="text-sm text-gray-500">Dismiss</button>
+        <button onClick={dismiss} className="text-sm text-gray-500">
+          Dismiss Forever
+        </button>
       </div>
       <ul className="space-y-1">
         {tasks.map((task) => {
@@ -60,14 +46,11 @@ const OnboardingPanel: React.FC<Props> = ({ role, userId }) => {
                 type="checkbox"
                 className="mr-2"
                 checked={done}
-                onChange={() => !done && completeTask(task.id)}
+                onChange={() => !done && completeTask(task.id as any)}
               />
-              <a
-                href={task.link}
-                className={`hover:underline ${done ? 'line-through text-gray-600' : ''}`}
-              >
+              <span className={done ? "line-through text-gray-600" : ""}>
                 {task.label}
-              </a>
+              </span>
             </li>
           );
         })}

--- a/installer-app/src/lib/hooks/useOnboardingState.ts
+++ b/installer-app/src/lib/hooks/useOnboardingState.ts
@@ -1,24 +1,41 @@
-import { useCallback, useEffect, useState } from 'react';
-import supabase from '../supabaseClient';
+import { useCallback, useEffect, useState } from "react";
+import supabase from "../supabaseClient";
+
+type Status = {
+  installer_started_job: boolean;
+  sales_created_quote: boolean;
+  manager_reviewed_job: boolean;
+  admin_invited_user: boolean;
+  dismissed: boolean;
+};
 
 export default function useOnboardingState(userId: string | null) {
-  const [completedTasks, setCompletedTasks] = useState<string[]>([]);
-  const [dismissed, setDismissed] = useState(false);
+  const [status, setStatus] = useState<Status | null>(null);
 
   const load = useCallback(async () => {
     if (!userId) return;
     const { data } = await supabase
-      .from('user_settings')
-      .select('onboarding_completed_tasks,onboarding_dismissed_at')
-      .eq('user_id', userId)
+      .from("user_onboarding_status")
+      .select("*")
+      .eq("user_id", userId)
       .maybeSingle();
     if (!data) {
-      await supabase.from('user_settings').insert({ user_id: userId });
-      setCompletedTasks([]);
-      setDismissed(false);
+      await supabase.from("user_onboarding_status").insert({ user_id: userId });
+      setStatus({
+        installer_started_job: false,
+        sales_created_quote: false,
+        manager_reviewed_job: false,
+        admin_invited_user: false,
+        dismissed: false,
+      });
     } else {
-      setCompletedTasks(data.onboarding_completed_tasks ?? []);
-      setDismissed(!!data.onboarding_dismissed_at);
+      setStatus({
+        installer_started_job: data.installer_started_job,
+        sales_created_quote: data.sales_created_quote,
+        manager_reviewed_job: data.manager_reviewed_job,
+        admin_invited_user: data.admin_invited_user,
+        dismissed: data.dismissed,
+      });
     }
   }, [userId]);
 
@@ -27,26 +44,33 @@ export default function useOnboardingState(userId: string | null) {
   }, [load]);
 
   const completeTask = useCallback(
-    async (taskId: string) => {
-      if (!userId) return;
-      const updated = Array.from(new Set([...completedTasks, taskId]));
-      setCompletedTasks(updated);
+    async (taskId: keyof Omit<Status, "dismissed">) => {
+      if (!userId || !status) return;
+      const fields: Partial<Status> = { [taskId]: true } as any;
+      setStatus({ ...status, ...fields });
       await supabase
-        .from('user_settings')
-        .update({ onboarding_completed_tasks: updated })
-        .eq('user_id', userId);
+        .from("user_onboarding_status")
+        .update(fields)
+        .eq("user_id", userId);
     },
-    [userId, completedTasks],
+    [userId, status],
   );
 
   const dismiss = useCallback(async () => {
-    if (!userId) return;
-    setDismissed(true);
+    if (!userId || !status) return;
+    setStatus({ ...status, dismissed: true });
     await supabase
-      .from('user_settings')
-      .update({ onboarding_dismissed_at: new Date().toISOString() })
-      .eq('user_id', userId);
-  }, [userId]);
+      .from("user_onboarding_status")
+      .update({ dismissed: true })
+      .eq("user_id", userId);
+  }, [userId, status]);
+
+  const completedTasks = status
+    ? (Object.entries(status) as [keyof Status, boolean][])
+        .filter(([k, v]) => k !== "dismissed" && v)
+        .map(([k]) => k as string)
+    : [];
+  const dismissed = status?.dismissed ?? false;
 
   return { completedTasks, dismissed, completeTask, dismiss } as const;
 }

--- a/installer-app/src/lib/updateUserOnboarding.ts
+++ b/installer-app/src/lib/updateUserOnboarding.ts
@@ -1,0 +1,17 @@
+import supabase from "./supabaseClient";
+
+export type OnboardingTask =
+  | "installer_started_job"
+  | "sales_created_quote"
+  | "manager_reviewed_job"
+  | "admin_invited_user";
+
+export default async function updateUserOnboarding(
+  userId: string,
+  task: OnboardingTask,
+) {
+  if (!userId) return;
+  await supabase
+    .from("user_onboarding_status")
+    .upsert({ user_id: userId, [task]: true }, { onConflict: "user_id" });
+}

--- a/schema-lock.sql
+++ b/schema-lock.sql
@@ -683,6 +683,23 @@ CREATE TABLE public.user_settings (
 ALTER TABLE public.user_settings OWNER TO postgres;
 
 --
+-- Name: user_onboarding_status; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.user_onboarding_status (
+    user_id uuid NOT NULL,
+    installer_started_job boolean DEFAULT false,
+    sales_created_quote boolean DEFAULT false,
+    manager_reviewed_job boolean DEFAULT false,
+    admin_invited_user boolean DEFAULT false,
+    dismissed boolean DEFAULT false,
+    updated_at timestamp with time zone DEFAULT now()
+);
+
+
+ALTER TABLE public.user_onboarding_status OWNER TO postgres;
+
+--
 -- Name: users; Type: TABLE; Schema: public; Owner: postgres
 --
 
@@ -894,6 +911,14 @@ ALTER TABLE ONLY public.user_roles
 
 ALTER TABLE ONLY public.user_settings
     ADD CONSTRAINT user_settings_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: user_onboarding_status user_onboarding_status_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_onboarding_status
+    ADD CONSTRAINT user_onboarding_status_pkey PRIMARY KEY (user_id);
 
 
 --
@@ -1259,6 +1284,27 @@ ALTER TABLE ONLY public.user_roles
 
 ALTER TABLE ONLY public.user_settings
     ADD CONSTRAINT user_settings_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id);
+
+
+--
+-- Name: user_onboarding_status user_onboarding_status_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.user_onboarding_status
+    ADD CONSTRAINT user_onboarding_status_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id);
+
+
+--
+-- Name: user_onboarding_status Allow user to update their onboarding status; Type: POLICY; Schema: public; Owner: postgres
+--
+
+CREATE POLICY "Allow user to update their onboarding status" ON public.user_onboarding_status FOR UPDATE USING ((auth.uid() = user_id)) WITH CHECK ((auth.uid() = user_id));
+
+--
+-- Name: user_onboarding_status Allow user to read their onboarding status; Type: POLICY; Schema: public; Owner: postgres
+--
+
+CREATE POLICY "Allow user to read their onboarding status" ON public.user_onboarding_status FOR SELECT USING ((auth.uid() = user_id));
 
 
 --
@@ -1748,6 +1794,12 @@ ALTER TABLE public.qa_reviews ENABLE ROW LEVEL SECURITY;
 --
 
 ALTER TABLE public.signed_checklists ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: user_onboarding_status; Type: ROW SECURITY; Schema: public; Owner: postgres
+--
+
+ALTER TABLE public.user_onboarding_status ENABLE ROW LEVEL SECURITY;
 
 --
 -- PostgreSQL database dump complete


### PR DESCRIPTION
## Summary
- create `user_onboarding_status` table with RLS
- add updateUserOnboarding helper
- redesign OnboardingPanel to read role-based tasks from table
- track onboarding actions for job start, quotes, QA reviews and invites
- wire panel into dashboards

## Testing
- `npm run format --silent`
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858c86102dc832dbaf4b9c51df0af68