### PR TITLE
Implement lead funnel metrics and Stripe payment integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ This repository contains the Vite + React Installer App located in the `installe
    echo "VITE_SUPABASE_URL=YOUR_SUPABASE_URL" >> .env
    echo "VITE_SUPABASE_API_KEY=YOUR_SUPABASE_ANON_KEY" >> .env
    # or VITE_SUPABASE_ANON_KEY
-   ```
+   echo "STRIPE_SECRET_KEY=your-stripe-secret" >> .env
+   echo "STRIPE_WEBHOOK_SECRET=your-stripe-webhook" >> .env
+  ```
 
 4. **Start the dev server:**
 

--- a/installer-app/api/migrations/V6_create_lead_funnel_metrics_view.sql
+++ b/installer-app/api/migrations/V6_create_lead_funnel_metrics_view.sql
@@ -1,0 +1,35 @@
+create or replace view lead_funnel_metrics as
+select
+  sales_rep_id,
+  count(*) filter (where status = 'new') as leads_new,
+  count(*) filter (where status = 'contacted') as leads_contacted,
+  count(*) filter (where status = 'quoted') as leads_quoted,
+  count(*) filter (where status = 'converted') as leads_converted,
+  count(*) as total_leads,
+  round(100.0 * count(*) filter (where status = 'converted') / nullif(count(*), 0), 2) as conversion_rate,
+  avg(quote_created_at - created_at) as avg_time_to_quote,
+  avg(job_created_at - created_at) as avg_time_to_job
+from (
+  select
+    l.id,
+    l.sales_rep_id,
+    l.status,
+    l.created_at,
+    (select min(q.created_at) from quotes q where q.lead_id = l.id) as quote_created_at,
+    (select min(j.created_at) from jobs j where j.lead_id = l.id) as job_created_at
+  from leads l
+) enriched
+group by sales_rep_id;
+
+alter view lead_funnel_metrics enable row level security;
+
+create policy "Allow sales, managers, admins to view lead funnel metrics"
+on lead_funnel_metrics
+for select
+using (
+  exists (
+    select 1 from user_roles
+    where user_id = auth.uid()
+    and role in ('Sales', 'Manager', 'Admin')
+  )
+);

--- a/installer-app/api/stripe/create-checkout-session.ts
+++ b/installer-app/api/stripe/create-checkout-session.ts
@@ -1,0 +1,53 @@
+import { createClient } from '@supabase/supabase-js';
+import Stripe from 'stripe';
+
+const supabaseUrl =
+  process.env.VITE_SUPABASE_URL ||
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  process.env.SUPABASE_URL;
+const supabaseAnonKey =
+  process.env.VITE_SUPABASE_API_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  process.env.SUPABASE_ANON_KEY;
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+const stripeSecret = process.env.STRIPE_SECRET_KEY || '';
+const baseUrl = process.env.BASE_URL || 'http://localhost:5173';
+const stripe = new Stripe(stripeSecret, { apiVersion: '2024-04-10' });
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+  const { invoiceId } = req.body;
+  if (!invoiceId) return res.status(400).json({ error: 'Missing invoiceId' });
+
+  const { data: invoice, error } = await supabase
+    .from('invoices')
+    .select('id, invoice_total, client_id')
+    .eq('id', invoiceId)
+    .single();
+  if (error || !invoice) return res.status(404).json({ error: 'Invoice not found' });
+
+  const session = await stripe.checkout.sessions.create({
+    mode: 'payment',
+    payment_method_types: ['card'],
+    line_items: [
+      {
+        price_data: {
+          currency: 'usd',
+          product_data: { name: `Invoice ${invoice.id}` },
+          unit_amount: Math.round(Number(invoice.invoice_total) * 100),
+        },
+        quantity: 1,
+      },
+    ],
+    metadata: {
+      invoice_id: invoice.id,
+      client_id: invoice.client_id || '',
+    },
+    success_url: `${baseUrl}/invoices/${invoice.id}?success=1`,
+    cancel_url: `${baseUrl}/invoices/${invoice.id}?canceled=1`,
+  });
+
+  return res.status(200).json({ url: session.url });
+}

--- a/installer-app/api/stripe/webhook.ts
+++ b/installer-app/api/stripe/webhook.ts
@@ -1,0 +1,51 @@
+import { createClient } from '@supabase/supabase-js';
+import Stripe from 'stripe';
+import getRawBody from 'raw-body';
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+const supabaseUrl =
+  process.env.VITE_SUPABASE_URL ||
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  process.env.SUPABASE_URL;
+const supabaseAnonKey =
+  process.env.VITE_SUPABASE_API_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  process.env.SUPABASE_ANON_KEY;
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+const stripeSecret = process.env.STRIPE_SECRET_KEY || '';
+const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET || '';
+const stripe = new Stripe(stripeSecret, { apiVersion: '2024-04-10' });
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const sig = req.headers['stripe-signature'];
+  let event;
+  try {
+    const body = await getRawBody(req);
+    event = stripe.webhooks.constructEvent(body, sig, webhookSecret);
+  } catch (err) {
+    return res.status(400).send(`Webhook Error: ${err.message}`);
+  }
+
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object as Stripe.Checkout.Session;
+    const invoiceId = session.metadata?.invoice_id;
+    const amount = (session.amount_total || 0) / 100;
+    if (invoiceId) {
+      await supabase.from('payments').insert({
+        invoice_id: invoiceId,
+        amount,
+        payment_method: 'Credit Card (Gateway)',
+      });
+    }
+  }
+
+  res.status(200).json({ received: true });
+}

--- a/installer-app/package-lock.json
+++ b/installer-app/package-lock.json
@@ -15,7 +15,8 @@
         "react-dom": "^18.2.0",
         "react-icons": "^5.5.0",
         "react-router-dom": "^6.23.0",
-        "recharts": "^2.15.4"
+        "recharts": "^2.15.4",
+        "stripe": "^12.18.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.27.2",
@@ -6478,7 +6479,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6492,7 +6492,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7308,7 +7307,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -7449,7 +7447,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7459,7 +7456,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7518,7 +7514,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -8339,7 +8334,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8400,7 +8394,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -8435,7 +8428,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -8547,7 +8539,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8633,7 +8624,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8662,7 +8652,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -12449,7 +12438,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12698,7 +12686,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13406,6 +13393,21 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -14194,7 +14196,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -14214,7 +14215,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -14231,7 +14231,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -14250,7 +14249,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -14607,6 +14605,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "12.18.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-12.18.0.tgz",
+      "integrity": "sha512-cYjgBM2SY/dTm8Lr6eMyyONaHTZHA/QjHxFUIW5WH8FevSRIGAVtXEmBkUXF1fsqe7QvvRgQSGSJZmjDacegGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
       }
     },
     "node_modules/sucrase": {

--- a/installer-app/package.json
+++ b/installer-app/package.json
@@ -19,7 +19,8 @@
     "react-dom": "^18.2.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^6.23.0",
-    "recharts": "^2.15.4"
+    "recharts": "^2.15.4",
+    "stripe": "^12.18.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.27.2",

--- a/installer-app/src/app/invoices/InvoiceDetailPage.tsx
+++ b/installer-app/src/app/invoices/InvoiceDetailPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { SZButton } from '../../components/ui/SZButton';
 import { SZTable } from '../../components/ui/SZTable';
 import PaymentLoggingModal from '../../components/PaymentLoggingModal';
+import PayInvoiceButton from '../../components/PayInvoiceButton';
 import useInvoice from '../../lib/hooks/useInvoice';
 import usePayments from '../../lib/hooks/usePayments';
 import useAuth from '../../lib/hooks/useAuth';
@@ -33,6 +34,7 @@ const InvoiceDetailPage: React.FC = () => {
           Record Payment
         </SZButton>
       )}
+      {balance > 0 && <PayInvoiceButton invoiceId={invoice.id} />}
       <h2 className="text-lg font-semibold mt-4">Payments</h2>
       <SZTable headers={["Amount", "Method", "Date", "Note"]}>
         {payments.map((p) => (

--- a/installer-app/src/app/reports/LeadFunnelDashboardPage.tsx
+++ b/installer-app/src/app/reports/LeadFunnelDashboardPage.tsx
@@ -1,0 +1,74 @@
+import React, { useMemo } from 'react';
+import {
+  FunnelChart,
+  Funnel,
+  Tooltip,
+  LabelList,
+  ResponsiveContainer,
+} from 'recharts';
+import { SZTable } from '../../components/ui/SZTable';
+import { GlobalLoading, GlobalError, GlobalEmpty } from '../../components/global-states';
+import useLeadFunnelMetrics from '../../lib/hooks/useLeadFunnelMetrics';
+
+const LeadFunnelDashboardPage: React.FC = () => {
+  const [rows, { loading, error }] = useLeadFunnelMetrics();
+
+  const funnelData = useMemo(() => {
+    const totals = rows.reduce(
+      (acc, r) => {
+        acc.new += r.leads_new;
+        acc.contacted += r.leads_contacted;
+        acc.quoted += r.leads_quoted;
+        acc.converted += r.leads_converted;
+        return acc;
+      },
+      { new: 0, contacted: 0, quoted: 0, converted: 0 },
+    );
+    return [
+      { stage: 'New', value: totals.new },
+      { stage: 'Contacted', value: totals.contacted },
+      { stage: 'Quoted', value: totals.quoted },
+      { stage: 'Converted', value: totals.converted },
+    ];
+  }, [rows]);
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Lead Funnel</h1>
+      {loading && <GlobalLoading />}
+      {error && <GlobalError message={error} />}
+      {!loading && !error && rows.length === 0 && <GlobalEmpty message="No data" />}
+      {!loading && !error && rows.length > 0 && (
+        <>
+          <div className="h-64 bg-white p-4 rounded shadow">
+            <ResponsiveContainer width="100%" height="100%">
+              <FunnelChart width={400} height={250}>
+                <Tooltip />
+                <Funnel dataKey="value" data={funnelData} isAnimationActive>
+                  <LabelList dataKey="stage" position="right" />
+                </Funnel>
+              </FunnelChart>
+            </ResponsiveContainer>
+          </div>
+          <SZTable headers={[
+            'Sales Rep',
+            'Conversion Rate',
+            'Avg Time to Quote',
+            'Avg Time to Job',
+          ]}>
+            {rows.map((r) => (
+              <tr key={r.sales_rep_id ?? 'none'} className="border-t">
+                <td className="p-2 border">{r.sales_rep_id ?? 'Unassigned'}</td>
+                <td className="p-2 border">{r.conversion_rate?.toFixed(2)}%</td>
+                <td className="p-2 border">{r.avg_time_to_quote ?? '-'}</td>
+                <td className="p-2 border">{r.avg_time_to_job ?? '-'}</td>
+              </tr>
+            ))}
+          </SZTable>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default LeadFunnelDashboardPage;

--- a/installer-app/src/components/PayInvoiceButton.tsx
+++ b/installer-app/src/components/PayInvoiceButton.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { SZButton } from './ui/SZButton';
+
+interface Props {
+  invoiceId: string;
+}
+
+const PayInvoiceButton: React.FC<Props> = ({ invoiceId }) => {
+  const [loading, setLoading] = useState(false);
+
+  const handleClick = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/stripe/create-checkout-session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ invoiceId }),
+      });
+      const data = await res.json();
+      if (data.url) {
+        window.location.href = data.url as string;
+      }
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <SZButton size="sm" onClick={handleClick} disabled={loading}>
+      {loading ? 'Loading...' : 'Pay with Card'}
+    </SZButton>
+  );
+};
+
+export default PayInvoiceButton;

--- a/installer-app/src/lib/hooks/useLeadFunnelMetrics.ts
+++ b/installer-app/src/lib/hooks/useLeadFunnelMetrics.ts
@@ -1,0 +1,41 @@
+import { useState, useEffect, useCallback } from 'react';
+import supabase from '../supabaseClient';
+
+export interface LeadFunnelRow {
+  sales_rep_id: string | null;
+  leads_new: number;
+  leads_contacted: number;
+  leads_quoted: number;
+  leads_converted: number;
+  total_leads: number;
+  conversion_rate: number;
+  avg_time_to_quote: string | null;
+  avg_time_to_job: string | null;
+}
+
+export default function useLeadFunnelMetrics() {
+  const [rows, setRows] = useState<LeadFunnelRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchMetrics = useCallback(async () => {
+    setLoading(true);
+    const { data, error } = await supabase
+      .from('lead_funnel_metrics')
+      .select('*');
+    if (error) {
+      setError(error.message);
+      setRows([]);
+    } else {
+      setRows((data as LeadFunnelRow[]) || []);
+      setError(null);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    fetchMetrics();
+  }, [fetchMetrics]);
+
+  return [rows, { loading, error, refresh: fetchMetrics }] as const;
+}

--- a/installer-app/src/routes.ts
+++ b/installer-app/src/routes.ts
@@ -39,6 +39,7 @@ import ReportsPage from "./app/reports/ReportsPage";
 import TechnicianPayReportPage from "./app/reports/TechnicianPayReportPage";
 import InvoiceAgingPage from "./app/reports/InvoiceAgingPage";
 import RevenueDashboardPage from "./app/reports/RevenueDashboardPage";
+import LeadFunnelDashboardPage from "./app/reports/LeadFunnelDashboardPage";
 import LeadsPage from "./app/crm/LeadsPage";
 import PaymentReportPage from "./app/admin/reports/payments/PaymentReportPage";
 import InventoryAlertsPage from "./app/admin/InventoryAlertsPage";
@@ -292,6 +293,12 @@ export const ROUTES: RouteConfig[] = [
     element: React.createElement(RevenueDashboardPage),
     role: ["Admin", "Finance"],
     label: "Revenue",
+  },
+  {
+    path: "/reports/lead-funnel",
+    element: React.createElement(LeadFunnelDashboardPage),
+    role: ["Sales", "Manager", "Admin"],
+    label: "Lead Funnel",
   },
   {
     path: "/reports/invoice-aging",


### PR DESCRIPTION
## Summary
- add Lead Funnel metrics SQL view with RLS policy
- provide hook `useLeadFunnelMetrics` and dashboard page
- add PayInvoiceButton and Stripe API routes
- support payments via checkout session and webhook
- expose Stripe env vars in setup docs

## Testing
- `npm test` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6858c913a8a4832d932bd6812af91233