### PR TITLE
Add material types management

### DIFF
--- a/installer-app/api/migrations/035_create_material_types.sql
+++ b/installer-app/api/migrations/035_create_material_types.sql
@@ -1,0 +1,28 @@
+create table if not exists material_types (
+  id uuid primary key default uuid_generate_v4(),
+  name text not null,
+  unit_of_measure text,
+  default_cost numeric,
+  retail_price numeric,
+  created_by uuid references auth.users(id),
+  created_at timestamptz default now()
+);
+
+alter table material_types enable row level security;
+
+create policy "Allow Admins to manage material types"
+  on material_types for all
+  using (
+    exists (
+      select 1 from user_roles
+      where user_id = auth.uid()
+      and role = 'Admin'
+    )
+  )
+  with check (
+    exists (
+      select 1 from user_roles
+      where user_id = auth.uid()
+      and role = 'Admin'
+    )
+  );

--- a/installer-app/src/lib/hooks/useMaterialTypes.ts
+++ b/installer-app/src/lib/hooks/useMaterialTypes.ts
@@ -18,7 +18,7 @@ export default function useMaterialTypes() {
   const fetchMaterials = useCallback(async () => {
     setLoading(true);
     const { data, error } = await supabase
-      .from<MaterialType>("materials")
+      .from<MaterialType>("material_types")
       .select(
         "id, name, unit_of_measure, default_cost, retail_price, created_at",
       )
@@ -36,7 +36,7 @@ export default function useMaterialTypes() {
   const createMaterial = useCallback(
     async (input: Omit<MaterialType, "id" | "created_at">) => {
       const { data, error } = await supabase
-        .from<MaterialType>("materials")
+        .from<MaterialType>("material_types")
         .insert(input)
         .select()
         .single();
@@ -50,7 +50,7 @@ export default function useMaterialTypes() {
   const updateMaterial = useCallback(
     async (id: string, input: Omit<MaterialType, "id" | "created_at">) => {
       const { data, error } = await supabase
-        .from<MaterialType>("materials")
+        .from<MaterialType>("material_types")
         .update(input)
         .eq("id", id)
         .select()
@@ -63,7 +63,7 @@ export default function useMaterialTypes() {
   );
 
   const deleteMaterial = useCallback(async (id: string) => {
-    const { error } = await supabase.from("materials").delete().eq("id", id);
+    const { error } = await supabase.from("material_types").delete().eq("id", id);
     if (error) throw error;
     setMaterials((list) => list.filter((m) => m.id !== id));
   }, []);

--- a/schema-lock.sql
+++ b/schema-lock.sql
@@ -579,6 +579,22 @@ CREATE TABLE public.materials (
 ALTER TABLE public.materials OWNER TO postgres;
 
 --
+-- Name: material_types; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.material_types (
+    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    name text NOT NULL,
+    unit_of_measure text,
+    default_cost numeric,
+    retail_price numeric,
+    created_by uuid,
+    created_at timestamp with time zone DEFAULT now()
+);
+
+ALTER TABLE public.material_types OWNER TO postgres;
+
+--
 -- Name: payments; Type: TABLE; Schema: public; Owner: postgres
 --
 
@@ -846,6 +862,14 @@ ALTER TABLE ONLY public.leads
 
 ALTER TABLE ONLY public.materials
     ADD CONSTRAINT materials_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: material_types material_types_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.material_types
+    ADD CONSTRAINT material_types_pkey PRIMARY KEY (id);
 
 
 --
@@ -1724,6 +1748,12 @@ ALTER TABLE public.leads ENABLE ROW LEVEL SECURITY;
 --
 
 ALTER TABLE public.materials ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: material_types; Type: ROW SECURITY; Schema: public; Owner: postgres
+--
+
+ALTER TABLE public.material_types ENABLE ROW LEVEL SECURITY;
 
 --
 -- Name: payments; Type: ROW SECURITY; Schema: public; Owner: postgres


### PR DESCRIPTION
## Summary
- create `material_types` migration and RLS policies
- update schema-lock with new `material_types` table
- switch Material Types hook to use new table

## Testing
- `npm test` *(fails: InstallVerificationStep and JobDetailPage tests)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858c988dba0832da4e77bc96fbf4e74