### PR TITLE
Implement lead funnel metrics dashboard

### DIFF
--- a/installer-app/api/migrations/036_update_lead_funnel_metrics_view.sql
+++ b/installer-app/api/migrations/036_update_lead_funnel_metrics_view.sql
@@ -1,0 +1,34 @@
+create or replace view lead_funnel_metrics as
+select
+  sales_rep_id,
+  count(*) filter (where status = 'new') as leads_new,
+  count(*) filter (where status = 'contacted') as leads_contacted,
+  count(*) filter (where status = 'quoted') as leads_quoted,
+  count(*) filter (where status = 'converted') as leads_converted,
+  count(*) as total_leads,
+  round(100.0 * count(*) filter (where status = 'converted') / nullif(count(*), 0), 2) as conversion_rate,
+  avg(quote_created_at - created_at) as avg_time_to_quote,
+  avg(job_created_at - created_at) as avg_time_to_job
+from (
+  select
+    l.id,
+    l.sales_rep_id,
+    l.status,
+    l.created_at,
+    (select min(q.created_at) from quotes q where q.lead_id = l.id) as quote_created_at,
+    (select min(j.created_at) from jobs j where j.lead_id = l.id) as job_created_at
+  from leads l
+) enriched
+group by sales_rep_id;
+
+alter view lead_funnel_metrics enable row level security;
+
+create policy "Allow sales, managers, admins to view lead funnel metrics"
+  on lead_funnel_metrics for select
+  using (
+    exists (
+      select 1 from user_roles
+      where user_id = auth.uid()
+        and role in ('Sales', 'Manager', 'Admin')
+    )
+  );

--- a/installer-app/src/app/reports/LeadFunnelDashboardPage.tsx
+++ b/installer-app/src/app/reports/LeadFunnelDashboardPage.tsx
@@ -1,6 +1,3 @@
-
-import React, { useEffect, useState, useMemo } from "react";
-
 import React, { useState } from "react";
 import useLeadFunnelMetrics from "../../lib/hooks/useLeadFunnelMetrics";
 import useSalesReps from "../../lib/hooks/useSalesReps";
@@ -13,151 +10,43 @@ import {
   ResponsiveContainer,
 } from "recharts";
 
-import supabase from "../../lib/supabaseClient";
-import {
-  GlobalLoading,
-  GlobalError,
-  GlobalEmpty,
-} from "../../components/global-states";
-import { SZTable } from "../../components/ui/SZTable";
-
-interface FunnelRow {
-  sales_rep_id: string | null;
-  sales_rep_email: string | null;
-  total_leads: number;
-  leads_with_quotes: number;
-  leads_converted_to_jobs: number;
-  quote_conversion_rate: number;
-  job_conversion_rate: number;
-}
-
 const LeadFunnelDashboardPage: React.FC = () => {
-  const [rows, setRows] = useState<FunnelRow[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [rep, setRep] = useState<string>("");
-
-  useEffect(() => {
-    async function load() {
-      setLoading(true);
-      const { data, error } = await supabase
-        .from("lead_funnel_metrics")
-        .select("*")
-        .order("sales_rep_email", { ascending: true });
-      if (error) {
-        console.error(error);
-        setError(error.message);
-        setRows([]);
-      } else {
-        setRows((data as FunnelRow[]) || []);
-        setError(null);
-      }
-      setLoading(false);
-    }
-    load();
-  }, []);
-
-  const filtered = useMemo(
-    () => (rep ? rows.filter((r) => r.sales_rep_id === rep) : rows),
-    [rows, rep],
-  );
-
-  const totals = useMemo(() => {
-    return filtered.reduce(
-      (acc, r) => ({
-        leads: acc.leads + r.total_leads,
-        quotes: acc.quotes + r.leads_with_quotes,
-        jobs: acc.jobs + r.leads_converted_to_jobs,
-      }),
-      { leads: 0, quotes: 0, jobs: 0 },
-    );
-  }, [filtered]);
-
-  const funnelData = [
-    { label: "Leads", value: totals.leads },
-    { label: "With Quotes", value: totals.quotes },
-    { label: "Converted to Jobs", value: totals.jobs },
-  ];
-
-
-const LeadFunnelDashboardPage: React.FC = () => {
-  const { metrics, loading, error, fetchMetrics } = useLeadFunnelMetrics();
+  const { metrics, loading, error } = useLeadFunnelMetrics();
   const { reps } = useSalesReps();
   const [rep, setRep] = useState<string>("");
 
-  const selectedMetrics = rep
-    ? metrics.filter((m) => m.sales_rep_id === rep)
-    : metrics;
+  const filtered = rep ? metrics.filter((m) => m.sales_rep_id === rep) : metrics;
 
-  const funnelTotals = selectedMetrics.length
-    ? selectedMetrics.reduce(
-        (acc, m) => {
-          acc.total_leads += m.total_leads;
-          acc.leads_with_quotes += m.leads_with_quotes;
-          acc.leads_converted_to_jobs += m.leads_converted_to_jobs;
-          return acc;
-        },
-        { total_leads: 0, leads_with_quotes: 0, leads_converted_to_jobs: 0 },
-      )
-    : { total_leads: 0, leads_with_quotes: 0, leads_converted_to_jobs: 0 };
+  const totals = filtered.reduce(
+    (acc, m) => {
+      acc.leads_new += m.leads_new;
+      acc.leads_contacted += m.leads_contacted;
+      acc.leads_quoted += m.leads_quoted;
+      acc.leads_converted += m.leads_converted;
+      return acc;
+    },
+    { leads_new: 0, leads_contacted: 0, leads_quoted: 0, leads_converted: 0 },
+  );
 
   const chartData = [
-    { label: "Leads", value: funnelTotals.total_leads },
-    { label: "With Quotes", value: funnelTotals.leads_with_quotes },
-    { label: "Converted to Jobs", value: funnelTotals.leads_converted_to_jobs },
+    { label: "New", value: totals.leads_new },
+    { label: "Contacted", value: totals.leads_contacted },
+    { label: "Quoted", value: totals.leads_quoted },
+    { label: "Converted", value: totals.leads_converted },
   ];
-
-  const onFilterChange = async (id: string) => {
-    setRep(id);
-    await fetchMetrics(id || undefined);
-  };
-
 
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Lead Funnel</h1>
       <div>
-
-        <label htmlFor="rep" className="block text-sm font-medium text-gray-700">
-
         <label className="block text-sm font-medium" htmlFor="rep">
-
           Sales Rep
         </label>
         <select
           id="rep"
-
-          value={rep}
-          onChange={(e) => setRep(e.target.value)}
-          className="border rounded px-3 py-2"
-        >
-          <option value="">All</option>
-          {rows.map((r) =>
-            r.sales_rep_id ? (
-              <option key={r.sales_rep_id} value={r.sales_rep_id}>
-                {r.sales_rep_email || r.sales_rep_id}
-              </option>
-            ) : null,
-          )}
-        </select>
-      </div>
-      {loading && <GlobalLoading />}
-      {error && <GlobalError message={error} />}
-      {!loading && !error && rows.length === 0 && (
-        <GlobalEmpty message="No funnel data" />
-      )}
-      {!loading && !error && rows.length > 0 && (
-        <>
-          <div className="h-80 bg-white p-4 rounded shadow">
-            <ResponsiveContainer width="100%" height="100%">
-              <FunnelChart>
-                <Tooltip />
-                <Funnel dataKey="value" data={funnelData} isAnimationActive={false}>
-                  <LabelList position="right" dataKey="label" />
-
           className="border rounded px-2 py-1"
           value={rep}
-          onChange={(e) => onFilterChange(e.target.value)}
+          onChange={(e) => setRep(e.target.value)}
         >
           <option value="">All</option>
           {reps.map((r) => (
@@ -181,72 +70,32 @@ const LeadFunnelDashboardPage: React.FC = () => {
               </FunnelChart>
             </ResponsiveContainer>
           </div>
-
           <div className="overflow-x-auto">
             <SZTable
               headers={[
-                "Sales Rep Email",
-                "Leads",
-                "Quotes",
-                "Jobs",
-                "Quote Conversion Rate",
-                "Job Conversion Rate",
+                "Sales Rep",
+                "Conversion %",
+                "Avg Time to Quote",
+                "Avg Time to Job",
               ]}
             >
-              {filtered.map((r) => (
-                <tr
-                  key={r.sales_rep_id || "none"}
-                  className="border-t"
-                >
-                  <td className="p-2 border">{r.sales_rep_email || "N/A"}</td>
-                  <td className="p-2 border text-right">{r.total_leads}</td>
-                  <td className="p-2 border text-right">{r.leads_with_quotes}</td>
+              {filtered.map((m) => (
+                <tr key={m.sales_rep_id ?? "none"} className="border-t">
+                  <td className="p-2 border">{m.sales_rep_id ?? "Unassigned"}</td>
                   <td className="p-2 border text-right">
-                    {r.leads_converted_to_jobs}
+                    {m.conversion_rate ?? 0}%
                   </td>
                   <td className="p-2 border text-right">
-                    {r.quote_conversion_rate.toFixed(1)}%
+                    {m.avg_time_to_quote ?? "N/A"}
                   </td>
                   <td className="p-2 border text-right">
-                    {r.job_conversion_rate.toFixed(1)}%
+                    {m.avg_time_to_job ?? "N/A"}
                   </td>
                 </tr>
               ))}
             </SZTable>
           </div>
-        </>
-
-          <SZTable
-            headers={[
-              "Sales Rep Email",
-              "Leads",
-              "Quotes",
-              "Jobs",
-              "Quote Conversion %",
-              "Job Conversion %",
-            ]}
-          >
-            {selectedMetrics.map((m) => (
-              <tr key={m.sales_rep_id ?? "none"} className="border-t">
-                <td className="p-2 border">
-                  {m.sales_rep_email ?? "Unassigned"}
-                </td>
-                <td className="p-2 border text-right">{m.total_leads}</td>
-                <td className="p-2 border text-right">{m.leads_with_quotes}</td>
-                <td className="p-2 border text-right">
-                  {m.leads_converted_to_jobs}
-                </td>
-                <td className="p-2 border text-right">
-                  {m.quote_conversion_rate ?? 0}%
-                </td>
-                <td className="p-2 border text-right">
-                  {m.job_conversion_rate ?? 0}%
-                </td>
-              </tr>
-            ))}
-          </SZTable>
         </div>
-
       )}
     </div>
   );

--- a/installer-app/src/lib/hooks/useLeadFunnelMetrics.ts
+++ b/installer-app/src/lib/hooks/useLeadFunnelMetrics.ts
@@ -3,12 +3,14 @@ import supabase from "../supabaseClient";
 
 export interface LeadFunnelMetric {
   sales_rep_id: string | null;
-  sales_rep_email: string | null;
+  leads_new: number;
+  leads_contacted: number;
+  leads_quoted: number;
+  leads_converted: number;
   total_leads: number;
-  leads_with_quotes: number;
-  leads_converted_to_jobs: number;
-  quote_conversion_rate: number | null;
-  job_conversion_rate: number | null;
+  conversion_rate: number | null;
+  avg_time_to_quote: string | null;
+  avg_time_to_job: string | null;
 }
 
 export default function useLeadFunnelMetrics() {


### PR DESCRIPTION
## Summary
- update SQL view for lead funnel metrics and add RLS policy
- expose metrics through new migration
- clean up LeadFunnelDashboardPage to show new funnel data
- adjust useLeadFunnelMetrics hook for updated view

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6858d16993c0832da1dfa801974f439e