### PR TITLE
Add revenue reporting dashboard

### DIFF
--- a/installer-app/api/migrations/V6_update_revenue_by_month_view.sql
+++ b/installer-app/api/migrations/V6_update_revenue_by_month_view.sql
@@ -1,0 +1,22 @@
+create or replace view revenue_by_month as
+select
+  date_trunc('month', i.invoice_date) as month,
+  sum(i.total_due) as total_invoiced,
+  sum(coalesce(p.amount, 0)) as total_paid,
+  sum(i.total_due) - sum(coalesce(p.amount, 0)) as outstanding_balance
+from invoices i
+left join payments p on p.invoice_id = i.id
+group by month
+order by month desc;
+
+alter view revenue_by_month enable row level security;
+
+create policy "Allow finance/admin to view revenue" on revenue_by_month
+for select
+using (
+  exists (
+    select 1 from user_roles
+    where user_id = auth.uid()
+    and role in ('Admin', 'Manager', 'Finance')
+  )
+);

--- a/installer-app/src/lib/hooks/useRevenueByMonth.ts
+++ b/installer-app/src/lib/hooks/useRevenueByMonth.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect } from "react";
+import supabase from "../supabaseClient";
+
+export interface RevenueByMonthRow {
+  month: string;
+  total_invoiced: number;
+  total_paid: number;
+  outstanding_balance: number;
+}
+
+export default function useRevenueByMonth() {
+  const [data, setData] = useState<RevenueByMonthRow[]>([]);
+
+  useEffect(() => {
+    supabase
+      .from("revenue_by_month")
+      .select("*")
+      .order("month", { ascending: true })
+      .then((res) => setData((res.data as RevenueByMonthRow[]) || []));
+  }, []);
+
+  return data;
+}


### PR DESCRIPTION
## Summary
- create `revenue_by_month` SQL view and enable RLS
- add policy restricting access to Admin, Manager and Finance
- add hook `useRevenueByMonth`
- enhance `RevenueDashboardPage` with metrics, chart and table

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6858d1783de4832d95bc35f1a0c9f3e7