### PR TITLE
Add initiate_payment RPC validation migration

### DIFF
--- a/installer-app/api/migrations/V7_harden_initiate_payment_rpc.sql
+++ b/installer-app/api/migrations/V7_harden_initiate_payment_rpc.sql
@@ -1,0 +1,35 @@
+-- Add input validation to initiate_payment RPC
+create or replace function initiate_payment(
+  p_invoice_id uuid,
+  p_amount numeric
+)
+returns text
+language plpgsql
+security definer
+as $$
+declare
+  v_invoice_exists boolean;
+  v_stripe_session_id text;
+begin
+  -- Input Validation: ensure invoice exists
+  select exists(select 1 from public.invoices where id = p_invoice_id)
+    into v_invoice_exists;
+  if not v_invoice_exists then
+    raise exception 'Payment initiation failed: Invoice ID % does not exist.', p_invoice_id;
+  end if;
+
+  -- Input Validation: ensure amount is positive
+  if p_amount <= 0 then
+    raise exception 'Payment initiation failed: Amount must be greater than zero. Received %', p_amount;
+  end if;
+
+  -- Log attempt
+  raise notice 'Attempting to initiate payment for Invoice ID: %, Amount: %', p_invoice_id, p_amount;
+
+  -- Return mock Stripe session ID
+  v_stripe_session_id := 'cs_mock_' || replace(p_invoice_id::text, '-', '');
+  return v_stripe_session_id;
+end;
+$$;
+
+grant execute on function initiate_payment(uuid, numeric) to authenticated;


### PR DESCRIPTION
## Summary
- add SQL migration to harden initiate_payment RPC
- embed new RPC in schema lock

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b131221c832d8fe757c46db92c45