### PR TITLE
Implement Supabase-based quote pages

### DIFF
--- a/installer-app/src/views/quotes/QuoteDetailPage.tsx
+++ b/installer-app/src/views/quotes/QuoteDetailPage.tsx
@@ -1,0 +1,45 @@
+import React, { useMemo } from "react";
+import { useParams, Link } from "react-router-dom";
+import { SZTable } from "../../components/ui/SZTable";
+import { SZButton } from "../../components/ui/SZButton";
+import useQuotes from "../../lib/hooks/useQuotes";
+import { useAuth } from "../../lib/hooks/useAuth";
+
+const QuoteDetailPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const { user, role } = useAuth();
+  const [quotes, { updateQuoteStatus }] = useQuotes();
+  const quote = useMemo(() => quotes.find((q) => q.id === id), [quotes, id]);
+
+  if (!quote) return <div className="p-4">Loading...</div>;
+
+  const canEdit = role === "Sales" && user?.id === quote.created_by && quote.status === "draft";
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Quote Detail</h1>
+      <div>Status: {quote.status}</div>
+      <div>Client: {quote.client_name}</div>
+      <div className="overflow-x-auto">
+        <SZTable headers={["Description", "Qty", "Price", "Total"]}>
+          {quote.items?.map((it) => (
+            <tr key={it.id} className="border-t">
+              <td className="p-2 border">{it.description}</td>
+              <td className="p-2 border">{it.quantity}</td>
+              <td className="p-2 border">${it.unit_price.toFixed(2)}</td>
+              <td className="p-2 border">${(it.total ?? it.quantity * it.unit_price).toFixed(2)}</td>
+            </tr>
+          ))}
+        </SZTable>
+      </div>
+      {canEdit && (
+        <SZButton size="sm" onClick={() => updateQuoteStatus(quote.id, "pending")}>Submit Quote</SZButton>
+      )}
+      <Link to="/quotes" className="underline text-blue-600">
+        Back
+      </Link>
+    </div>
+  );
+};
+
+export default QuoteDetailPage;

--- a/installer-app/src/views/quotes/QuotesPage.tsx
+++ b/installer-app/src/views/quotes/QuotesPage.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import { SZButton } from "../../components/ui/SZButton";
+import { SZTable } from "../../components/ui/SZTable";
+import QuoteFormModal, { QuoteData } from "../../components/modals/QuoteFormModal";
+import useQuotes from "../../lib/hooks/useQuotes";
+import { useAuth } from "../../lib/hooks/useAuth";
+
+const QuotesPage: React.FC = () => {
+  const { user, role } = useAuth();
+  const [quotes, { loading, error, createQuote, updateQuote, updateQuoteStatus }] = useQuotes();
+  const [active, setActive] = useState<QuoteData & { id?: string } | null>(null);
+  const [open, setOpen] = useState(false);
+
+  const handleSave = async (data: QuoteData) => {
+    if (data.id) {
+      await updateQuote(data.id, {
+        client_id: data.client_id,
+        items: data.lines.map((l) => ({
+          description: l.material,
+          quantity: l.qty,
+          unit_price: l.price,
+          total: l.qty * l.price,
+        })),
+      });
+    } else {
+      await createQuote({
+        client_id: data.client_id,
+        items: data.lines.map((l) => ({
+          description: l.material,
+          quantity: l.qty,
+          unit_price: l.price,
+          total: l.qty * l.price,
+        })),
+      });
+    }
+    setOpen(false);
+    setActive(null);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">Quotes</h1>
+        <SZButton size="sm" onClick={() => setOpen(true)}>
+          New Quote
+        </SZButton>
+      </div>
+      {error && <div className="text-red-600">{error.message}</div>}
+      {loading ? (
+        <div>Loading...</div>
+      ) : (
+        <SZTable headers={["Client", "Total", "Status", "Actions"]}>
+          {quotes.map((q) => (
+            <tr key={q.id} className="border-t">
+              <td className="p-2 border">{q.client_name}</td>
+              <td className="p-2 border">${(q.total ?? 0).toFixed(2)}</td>
+              <td className="p-2 border">{q.status}</td>
+              <td className="p-2 border space-x-2">
+                <Link to={`/quotes/${q.id}`}>View</Link>
+                {role === "Sales" && user?.id === q.created_by && q.status === "draft" && (
+                  <SZButton size="sm" variant="secondary" onClick={() => { setActive(q as any); setOpen(true); }}>
+                    Edit
+                  </SZButton>
+                )}
+                {role === "Sales" && user?.id === q.created_by && q.status === "draft" && (
+                  <SZButton size="sm" onClick={() => updateQuoteStatus(q.id, "pending")}>Submit</SZButton>
+                )}
+              </td>
+            </tr>
+          ))}
+        </SZTable>
+      )}
+      <QuoteFormModal isOpen={open} onClose={() => setOpen(false)} onSave={handleSave} initialData={active ?? undefined} />
+    </div>
+  );
+};
+
+export default QuotesPage;


### PR DESCRIPTION
## Summary
- add line item support in `useQuotes` and call new RPCs
- return `updateQuoteStatus` in the hook
- create Sales-friendly Quotes and QuoteDetail pages under views

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e421f668832db1e8c18f40db489f