### PR TITLE
Replace in-memory invoice logic with Supabase data

### DIFF
--- a/installer-app/src/app/install-manager/InvoiceGenerator.tsx
+++ b/installer-app/src/app/install-manager/InvoiceGenerator.tsx
@@ -25,7 +25,7 @@ const InvoiceGenerator: React.FC = () => {
   }, []);
 
   const finalize = async (id: string) => {
-    await supabase.rpc('generate_invoice_for_job', { p_job_id: id });
+    await supabase.rpc('generate_invoice_from_job', { p_job_id: id });
     await supabase.from('jobs').update({ status: 'invoiced' }).eq('id', id);
     setJobs((js) => js.filter((j) => j.id !== id));
   };

--- a/installer-app/src/app/invoices/InvoiceDetailPage.tsx
+++ b/installer-app/src/app/invoices/InvoiceDetailPage.tsx
@@ -48,9 +48,30 @@ const InvoiceDetailPage: React.FC = () => {
     <div className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Invoice {invoice.id}</h1>
       <p>Client: {invoice.client_name}</p>
-      <p>Total: ${invoice.invoice_total.toFixed(2)}</p>
+      <div className="space-y-1">
+        <p>Subtotal: ${invoice.subtotal.toFixed(2)}</p>
+        <p>Discount: ${invoice.discount_amount.toFixed(2)}</p>
+        <p>Tax: ${invoice.tax_amount.toFixed(2)}</p>
+        <p>Fees: ${invoice.total_fees.toFixed(2)}</p>
+        <p className="font-semibold">Total: ${invoice.invoice_total.toFixed(2)}</p>
+      </div>
       <p>Amount Paid: ${totalPaid.toFixed(2)}</p>
       <p>Balance Due: ${balance.toFixed(2)}</p>
+      {invoice.line_items && invoice.line_items.length > 0 && (
+        <>
+          <h2 className="text-lg font-semibold mt-4">Line Items</h2>
+          <SZTable headers={["Description", "Qty", "Price", "Total"]}>
+            {invoice.line_items.map((item) => (
+              <tr key={item.id} className="border-t">
+                <td className="p-2 border">{item.description}</td>
+                <td className="p-2 border">{item.quantity}</td>
+                <td className="p-2 border">${item.unit_price.toFixed(2)}</td>
+                <td className="p-2 border">${item.line_total.toFixed(2)}</td>
+              </tr>
+            ))}
+          </SZTable>
+        </>
+      )}
       {['Admin', 'Finance'].includes(role) && (
         <div className="flex gap-2">
           <SZButton size="sm" onClick={() => setOpen(true)}>

--- a/installer-app/src/app/invoices/InvoicesPage.tsx
+++ b/installer-app/src/app/invoices/InvoicesPage.tsx
@@ -88,14 +88,17 @@ const InvoicesPageContent: React.FC = () => {
         <EmptyState message="No Invoices" />
       )}
       {!loading && !error && filtered.length > 0 && (
-        <SZTable headers={["Invoice", "Client", "Amount", "Paid", "Status", "Actions"]}>
+        <SZTable headers={["Invoice", "Client", "Total", "Tax", "Discount", "Fees", "Paid", "Status", "Actions"]}>
           {filtered.map((inv) => (
             <tr key={inv.id} className="border-t">
               <td className="p-2 border">
                 <a className="text-blue-600 underline" href={`/invoices/${inv.id}`}>{inv.id}</a>
               </td>
               <td className="p-2 border">{inv.client_name}</td>
-              <td className="p-2 border">${inv.amount.toFixed(2)}</td>
+              <td className="p-2 border">${inv.invoice_total.toFixed(2)}</td>
+              <td className="p-2 border">${inv.tax_amount.toFixed(2)}</td>
+              <td className="p-2 border">${inv.discount_amount.toFixed(2)}</td>
+              <td className="p-2 border">${inv.total_fees.toFixed(2)}</td>
               <td className="p-2 border">${inv.amount_paid?.toFixed(2) ?? '0.00'}</td>
               <td className="p-2 border">{inv.payment_status}</td>
               <td className="p-2 border">

--- a/installer-app/src/app/manager/QAReviewPanel.tsx
+++ b/installer-app/src/app/manager/QAReviewPanel.tsx
@@ -60,7 +60,7 @@ const QAReviewPanel: React.FC = () => {
         .eq("id", jobId);
       if (!error) {
         const { error: invErr } = await supabase.rpc(
-          "generate_invoice_for_job",
+          "generate_invoice_from_job",
           { p_job_id: jobId },
         );
         if (invErr) {

--- a/installer-app/src/lib/hooks/useInvoice.ts
+++ b/installer-app/src/lib/hooks/useInvoice.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import supabase from "../supabaseClient";
-import { Invoice } from "./useInvoices";
+import { Invoice, InvoiceLineItem } from "./useInvoices";
 
 export default function useInvoice(id: string | null) {
   const [invoice, setInvoice] = useState<Invoice | null>(null);
@@ -17,7 +17,7 @@ export default function useInvoice(id: string | null) {
     const { data, error } = await supabase
       .from("invoices")
       .select(
-        "id, job_id, quote_id, client_id, subtotal, discount_type, discount_amount, tax_rate, tax_amount, total_fees, invoice_total, amount_paid, payment_status, payment_method, stripe_session_id, invoice_date, due_date, paid_at, clients(name), jobs(clinic_name)",
+        "id, job_id, quote_id, client_id, subtotal, discount_type, discount_amount, tax_rate, tax_amount, total_fees, invoice_total, amount_paid, payment_status, payment_method, stripe_session_id, invoice_date, due_date, paid_at, clients(name), jobs(clinic_name), invoice_line_items(id, material_id, description, quantity, unit_price, line_total)",
       )
       .eq("id", id)
       .single();
@@ -35,6 +35,7 @@ export default function useInvoice(id: string | null) {
         payment_status: (data as any).payment_status ?? "unpaid",
         payment_method: (data as any).payment_method ?? null,
         stripe_session_id: (data as any).stripe_session_id ?? null,
+        line_items: (data as any).invoice_line_items ?? [],
       } as Invoice);
       setError(null);
     }

--- a/installer-app/src/lib/hooks/useJobs.ts
+++ b/installer-app/src/lib/hooks/useJobs.ts
@@ -136,7 +136,7 @@ export function useJobs() {
     await supabase.from("jobs").update({ status: newStatus }).eq("id", jobId);
 
     if (newStatus === "ready_for_invoice") {
-      await supabase.rpc("generate_invoice_for_job", { p_job_id: jobId });
+      await supabase.rpc("generate_invoice_from_job", { p_job_id: jobId });
     }
 
     await fetchJobs();


### PR DESCRIPTION
## Summary
- load invoices with related line items
- generate invoices using `generate_invoice_from_job` RPC
- display tax, discount and fee values in invoice list
- show invoice line items and totals on detail page
- update invoice generation calls across the app

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859eaebf574832d9ae63cb7b8ac3c32