### PR TITLE
Add InstallerPerformance report

### DIFF
--- a/installer-app/src/app/reports/InstallerPerformancePage.tsx
+++ b/installer-app/src/app/reports/InstallerPerformancePage.tsx
@@ -1,0 +1,158 @@
+import React, { useMemo, useState } from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { SZTable } from "../../components/ui/SZTable";
+import { SZButton } from "../../components/ui/SZButton";
+import { DateRangeFilter } from "../../components/ui/filters/DateRangeFilter";
+import { useInstallers } from "../../lib/hooks/useInstallers";
+import useInstallerPerformance, {
+  InstallerPerformanceRow,
+} from "../../lib/hooks/useInstallerPerformance";
+import {
+  GlobalLoading,
+  GlobalError,
+  GlobalEmpty,
+} from "../../components/global-states";
+
+function csvEscape(value: string | number | null) {
+  if (value === null || value === undefined) return "";
+  const str = String(value);
+  return `"${str.replace(/"/g, '""')}"`;
+}
+
+const InstallerPerformancePage: React.FC = () => {
+  const today = new Date().toISOString().slice(0, 10);
+  const past = new Date();
+  past.setDate(past.getDate() - 30);
+  const [range, setRange] = useState({
+    start: past.toISOString().slice(0, 10),
+    end: today,
+  });
+  const [installer, setInstaller] = useState("");
+  const { installers } = useInstallers();
+  const { rows, loading, error } = useInstallerPerformance(
+    range.start,
+    range.end,
+    installer || undefined,
+  );
+
+  const exportCSV = () => {
+    let csv = "Installer,Avg Duration,Callback Rate,Checklist Completion\n";
+    rows.forEach((r) => {
+      csv +=
+        [
+          csvEscape(r.installer_id),
+          r.avg_duration?.toFixed(2),
+          r.callback_rate?.toFixed(2),
+          r.completion_rate?.toFixed(2),
+        ].join(",") + "\n";
+    });
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "installer_performance.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const chartData = useMemo(() => {
+    return rows.map((r) => ({
+      installer: r.installer_id,
+      duration: r.avg_duration ?? 0,
+      callback: r.callback_rate ?? 0,
+      completion: r.completion_rate ?? 0,
+    }));
+  }, [rows]);
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Installer Performance</h1>
+      <div className="flex flex-wrap gap-4 items-end">
+        <DateRangeFilter value={range} onChange={setRange} />
+        <div>
+          <label className="block text-sm font-medium" htmlFor="installer">
+            Installer
+          </label>
+          <select
+            id="installer"
+            className="border rounded px-2 py-1"
+            value={installer}
+            onChange={(e) => setInstaller(e.target.value)}
+          >
+            <option value="">All</option>
+            {installers.map((i) => (
+              <option key={i.id} value={i.id}>
+                {i.full_name ?? i.id}
+              </option>
+            ))}
+          </select>
+        </div>
+        <SZButton size="sm" onClick={exportCSV}>
+          Export CSV
+        </SZButton>
+      </div>
+      {loading && <GlobalLoading />}
+      {error && <GlobalError message={error} />}
+      {!loading && !error && rows.length === 0 && (
+        <GlobalEmpty message="No performance data" />
+      )}
+      {!loading && !error && rows.length > 0 && (
+        <>
+          <div className="h-72 bg-white p-4 rounded shadow">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={chartData}
+                margin={{ top: 5, right: 20, bottom: 5, left: 0 }}
+              >
+                <XAxis dataKey="installer" />
+                <YAxis />
+                <Tooltip />
+                <Bar dataKey="duration" fill="#8884d8" name="Avg Duration" />
+                <Bar dataKey="callback" fill="#82ca9d" name="Callback Rate" />
+                <Bar
+                  dataKey="completion"
+                  fill="#f87171"
+                  name="Checklist Completion"
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="overflow-x-auto">
+            <SZTable
+              headers={[
+                "Installer",
+                "Avg Duration",
+                "Callback %",
+                "Checklist %",
+              ]}
+            >
+              {rows.map((r) => (
+                <tr key={r.installer_id} className="border-t">
+                  <td className="p-2 border">{r.installer_id}</td>
+                  <td className="p-2 border text-right">
+                    {r.avg_duration?.toFixed(2) ?? ""}
+                  </td>
+                  <td className="p-2 border text-right">
+                    {r.callback_rate?.toFixed(2) ?? ""}
+                  </td>
+                  <td className="p-2 border text-right">
+                    {r.completion_rate?.toFixed(2) ?? ""}
+                  </td>
+                </tr>
+              ))}
+            </SZTable>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default InstallerPerformancePage;

--- a/installer-app/src/lib/hooks/useInstallerPerformance.ts
+++ b/installer-app/src/lib/hooks/useInstallerPerformance.ts
@@ -1,0 +1,114 @@
+import { useEffect, useState } from "react";
+import supabase from "../supabaseClient";
+
+export interface InstallerPerformanceRow {
+  installer_id: string;
+  avg_duration: number | null;
+  callback_rate: number | null;
+  completion_rate: number | null;
+}
+
+export default function useInstallerPerformance(
+  start?: string,
+  end?: string,
+  installerId?: string,
+) {
+  const [rows, setRows] = useState<InstallerPerformanceRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true);
+      let jobsQuery = supabase
+        .from("jobs")
+        .select("id, installer_id, duration, callback_rate, created_at");
+      if (start) jobsQuery = jobsQuery.gte("created_at", start);
+      if (end) jobsQuery = jobsQuery.lte("created_at", end);
+      if (installerId) jobsQuery = jobsQuery.eq("installer_id", installerId);
+      const { data: jobs, error: jobsErr } = await jobsQuery;
+      if (jobsErr) {
+        setError(jobsErr.message);
+        setRows([]);
+        setLoading(false);
+        return;
+      }
+
+      let checklistQuery = supabase
+        .from("checklists")
+        .select("installer_id, completion_rate, created_at");
+      if (start) checklistQuery = checklistQuery.gte("created_at", start);
+      if (end) checklistQuery = checklistQuery.lte("created_at", end);
+      if (installerId)
+        checklistQuery = checklistQuery.eq("installer_id", installerId);
+      const { data: checklists, error: checklistErr } = await checklistQuery;
+      if (checklistErr) {
+        setError(checklistErr.message);
+        setRows([]);
+        setLoading(false);
+        return;
+      }
+
+      const map: Record<
+        string,
+        {
+          count: number;
+          dur: number;
+          cbr: number;
+          cbrCount: number;
+          cr: number;
+          crCount: number;
+        }
+      > = {};
+
+      (jobs ?? []).forEach((j: any) => {
+        const id = j.installer_id || "unknown";
+        if (!map[id])
+          map[id] = {
+            count: 0,
+            dur: 0,
+            cbr: 0,
+            cbrCount: 0,
+            cr: 0,
+            crCount: 0,
+          };
+        map[id].count += 1;
+        if (j.duration) map[id].dur += Number(j.duration);
+        if (j.callback_rate != null) {
+          map[id].cbr += Number(j.callback_rate);
+          map[id].cbrCount += 1;
+        }
+      });
+
+      (checklists ?? []).forEach((c: any) => {
+        const id = c.installer_id || "unknown";
+        if (!map[id])
+          map[id] = {
+            count: 0,
+            dur: 0,
+            cbr: 0,
+            cbrCount: 0,
+            cr: 0,
+            crCount: 0,
+          };
+        if (c.completion_rate != null) {
+          map[id].cr += Number(c.completion_rate);
+          map[id].crCount += 1;
+        }
+      });
+
+      const results: InstallerPerformanceRow[] = Object.keys(map).map((id) => ({
+        installer_id: id,
+        avg_duration: map[id].count ? map[id].dur / map[id].count : null,
+        callback_rate: map[id].cbrCount ? map[id].cbr / map[id].cbrCount : null,
+        completion_rate: map[id].crCount ? map[id].cr / map[id].crCount : null,
+      }));
+      setRows(results);
+      setError(null);
+      setLoading(false);
+    }
+    load();
+  }, [start, end, installerId]);
+
+  return { rows, loading, error } as const;
+}

--- a/installer-app/src/routes.ts
+++ b/installer-app/src/routes.ts
@@ -40,6 +40,7 @@ import TechnicianPayReportPage from "./app/reports/TechnicianPayReportPage";
 import InvoiceAgingPage from "./app/reports/InvoiceAgingPage";
 import LeadFunnelDashboardPage from "./app/reports/LeadFunnelDashboardPage";
 import RevenueDashboardPage from "./app/reports/RevenueDashboardPage";
+import InstallerPerformancePage from "./app/reports/InstallerPerformancePage";
 import LeadsPage from "./app/crm/LeadsPage";
 import PaymentReportPage from "./app/admin/reports/payments/PaymentReportPage";
 import InventoryAlertsPage from "./app/admin/InventoryAlertsPage";
@@ -282,6 +283,12 @@ export const ROUTES: RouteConfig[] = [
     element: React.createElement(TechnicianPayReportPage),
     roles: ["Admin", "Install Manager"],
     label: "Technician Pay",
+  },
+  {
+    path: "/reports/installers",
+    element: React.createElement(InstallerPerformancePage),
+    roles: ["Admin", "Manager"],
+    label: "Installer Performance",
   },
   {
     path: "/reports/revenue",


### PR DESCRIPTION
## Summary
- add `useInstallerPerformance` hook to aggregate job KPIs
- implement `InstallerPerformancePage` with charts, filters and CSV export
- register new page route under `/reports/installers`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a2090bac0832d85c0b4b863b638af