### PR TITLE
Add lead form page

### DIFF
--- a/installer-app/src/app/crm/LeadForm.tsx
+++ b/installer-app/src/app/crm/LeadForm.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { SZInput } from "../../components/ui/SZInput";
+import { SZButton } from "../../components/ui/SZButton";
+import supabase from "../../lib/supabaseClient";
+
+const LeadForm: React.FC = () => {
+  const navigate = useNavigate();
+  const [lead, setLead] = useState({
+    name: "",
+    email: "",
+    phone: "",
+    source: "",
+  });
+  const [errors, setErrors] = useState<{
+    name?: string;
+    email?: string;
+    phone?: string;
+  }>({});
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleChange = (key: string, value: string) => {
+    setLead((l) => ({ ...l, [key]: value }));
+  };
+
+  const validate = () => {
+    const errs: { name?: string; email?: string; phone?: string } = {};
+    if (!lead.name.trim()) errs.name = "Required";
+    if (!lead.email.trim()) errs.email = "Required";
+    if (!lead.phone.trim()) errs.phone = "Required";
+    return errs;
+  };
+
+  const handleSubmit = async () => {
+    const v = validate();
+    if (Object.keys(v).length) {
+      setErrors(v);
+      return;
+    }
+    setErrors({});
+    setSubmitting(true);
+    await supabase.from("leads").insert({
+      name: lead.name,
+      email: lead.email,
+      phone: lead.phone,
+      source: lead.source || null,
+      status: "new",
+    });
+    setSubmitting(false);
+    navigate("/crm/leads");
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-4 space-y-3">
+      <h1 className="text-2xl font-bold">New Lead</h1>
+      <SZInput
+        id="name"
+        label="Name"
+        value={lead.name}
+        onChange={(v) => handleChange("name", v)}
+        error={errors.name}
+      />
+      <SZInput
+        id="email"
+        label="Email"
+        value={lead.email}
+        onChange={(v) => handleChange("email", v)}
+        error={errors.email}
+      />
+      <SZInput
+        id="phone"
+        label="Phone"
+        value={lead.phone}
+        onChange={(v) => handleChange("phone", v)}
+        error={errors.phone}
+      />
+      <SZInput
+        id="source"
+        label="Source"
+        value={lead.source}
+        onChange={(v) => handleChange("source", v)}
+      />
+      <SZButton onClick={handleSubmit} isLoading={submitting} fullWidth>
+        Save Lead
+      </SZButton>
+    </div>
+  );
+};
+
+export default LeadForm;

--- a/installer-app/src/routes.ts
+++ b/installer-app/src/routes.ts
@@ -41,6 +41,7 @@ import InvoiceAgingPage from "./app/reports/InvoiceAgingPage";
 import LeadFunnelDashboardPage from "./app/reports/LeadFunnelDashboardPage";
 import RevenueDashboardPage from "./app/reports/RevenueDashboardPage";
 import LeadsPage from "./app/crm/LeadsPage";
+import LeadForm from "./app/crm/LeadForm";
 import PaymentReportPage from "./app/admin/reports/payments/PaymentReportPage";
 import InventoryAlertsPage from "./app/admin/InventoryAlertsPage";
 import UnderConstructionPage from "./app/UnderConstructionPage";
@@ -229,6 +230,12 @@ export const ROUTES: RouteConfig[] = [
     element: React.createElement(LeadsPage),
     roles: ["Sales", "Manager", "Admin"],
     label: "Leads",
+  },
+  {
+    path: "/crm/leads/new",
+    element: React.createElement(LeadForm),
+    roles: ["Sales"],
+    label: "Add Lead",
   },
   {
     path: "/sales/dashboard",


### PR DESCRIPTION
## Summary
- add LeadForm component for capturing new leads
- register `/crm/leads/new` route with sidebar entry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a21ea0394832db2bed583710b0a18