### PR TITLE
Add PurchaseOrdersPage

### DIFF
--- a/installer-app/src/app/inventory/PurchaseOrdersPage.tsx
+++ b/installer-app/src/app/inventory/PurchaseOrdersPage.tsx
@@ -1,0 +1,108 @@
+import React, { useState, useMemo } from "react";
+import { Navigate } from "react-router-dom";
+import { SZButton } from "../../components/ui/SZButton";
+import { SZTable } from "../../components/ui/SZTable";
+import {
+  GlobalLoading,
+  GlobalError,
+  GlobalEmpty,
+} from "../../components/global-states";
+import usePurchaseOrders from "../../lib/hooks/usePurchaseOrders";
+import useAuth from "../../lib/hooks/useAuth";
+import PurchaseOrderForm from "../../components/forms/PurchaseOrderForm";
+
+const PurchaseOrdersPage: React.FC = () => {
+  const { role, loading: authLoading } = useAuth();
+  const { orders, loading, error, createOrder, updateStatus, fetchOrders } =
+    usePurchaseOrders();
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [open, setOpen] = useState(false);
+
+  if (authLoading) return <GlobalLoading />;
+  if (role !== "Admin" && role !== "Install Manager") {
+    return <Navigate to="/unauthorized" replace />;
+  }
+
+  const filtered = useMemo(() => {
+    return statusFilter === "all"
+      ? orders
+      : orders.filter((o) => o.status === statusFilter);
+  }, [orders, statusFilter]);
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">Purchase Orders</h1>
+        <SZButton size="sm" onClick={() => setOpen(true)}>
+          New Purchase Order
+        </SZButton>
+      </div>
+      <div>
+        <label
+          htmlFor="status"
+          className="block text-sm font-medium text-gray-700"
+        >
+          Status
+        </label>
+        <select
+          id="status"
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className="border rounded px-3 py-2"
+        >
+          <option value="all">All</option>
+          <option value="draft">Draft</option>
+          <option value="submitted">Submitted</option>
+          <option value="received">Received</option>
+        </select>
+      </div>
+      {loading ? (
+        <GlobalLoading />
+      ) : error ? (
+        <GlobalError message={error} onRetry={fetchOrders} />
+      ) : filtered.length === 0 ? (
+        <GlobalEmpty message="No purchase orders found." />
+      ) : (
+        <SZTable headers={["Supplier", "Order Date", "Status", "Actions"]}>
+          {filtered.map((o) => (
+            <tr key={o.id} className="border-t">
+              <td className="p-2 border">{o.supplier}</td>
+              <td className="p-2 border">
+                {new Date(o.order_date).toLocaleDateString()}
+              </td>
+              <td className="p-2 border">{o.status}</td>
+              <td className="p-2 border space-x-2">
+                {o.status === "draft" && (
+                  <SZButton
+                    size="xs"
+                    onClick={() => updateStatus(o.id, "submitted")}
+                  >
+                    Submit
+                  </SZButton>
+                )}
+                {o.status !== "received" && (
+                  <SZButton
+                    size="xs"
+                    onClick={() => updateStatus(o.id, "received")}
+                  >
+                    Mark Received
+                  </SZButton>
+                )}
+              </td>
+            </tr>
+          ))}
+        </SZTable>
+      )}
+      <PurchaseOrderForm
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        onSave={async (data) => {
+          await createOrder(data);
+          setOpen(false);
+        }}
+      />
+    </div>
+  );
+};
+
+export default PurchaseOrdersPage;

--- a/installer-app/src/components/forms/PurchaseOrderForm.tsx
+++ b/installer-app/src/components/forms/PurchaseOrderForm.tsx
@@ -1,0 +1,133 @@
+import React, { useState, useEffect } from "react";
+import ModalWrapper from "../../installer/components/ModalWrapper";
+import { SZInput } from "../ui/SZInput";
+import { SZButton } from "../ui/SZButton";
+import useMaterialTypes from "../../lib/hooks/useMaterialTypes";
+
+export type PurchaseOrderInput = {
+  supplier: string;
+  order_date: string;
+  items: { material_type_id: string; qty: number }[];
+};
+
+export type PurchaseOrderFormProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (order: PurchaseOrderInput) => void;
+};
+
+const blankItem = { id: "", material_type_id: "", qty: 1 };
+
+const PurchaseOrderForm: React.FC<PurchaseOrderFormProps> = ({
+  isOpen,
+  onClose,
+  onSave,
+}) => {
+  const { materials } = useMaterialTypes();
+  const [supplier, setSupplier] = useState("");
+  const [orderDate, setOrderDate] = useState("");
+  const [items, setItems] = useState([ { ...blankItem } ]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isOpen) return;
+    setSupplier("");
+    setOrderDate("");
+    setItems([ { ...blankItem } ]);
+    setError(null);
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const addItem = () =>
+    setItems((its) => [...its, { ...blankItem, id: Date.now().toString() }]);
+
+  const removeItem = (idx: number) =>
+    setItems((its) => its.filter((_, i) => i !== idx));
+
+  const updateItem = (
+    idx: number,
+    key: "material_type_id" | "qty",
+    value: string | number,
+  ) => {
+    setItems((its) => its.map((it, i) => (i === idx ? { ...it, [key]: value } : it)));
+  };
+
+  const save = () => {
+    if (!supplier) {
+      setError("Supplier is required");
+      return;
+    }
+    if (!orderDate) {
+      setError("Order date is required");
+      return;
+    }
+    if (items.some((i) => !i.material_type_id || i.qty <= 0)) {
+      setError("All items must have material and qty");
+      return;
+    }
+    onSave({
+      supplier,
+      order_date: orderDate,
+      items: items.map(({ material_type_id, qty }) => ({ material_type_id, qty })),
+    });
+  };
+
+  return (
+    <ModalWrapper isOpen={isOpen} onClose={onClose}>
+      <h2 className="text-lg font-semibold mb-4">New Purchase Order</h2>
+      <div className="space-y-2">
+        <SZInput id="po_supplier" label="Supplier" value={supplier} onChange={setSupplier} />
+        <SZInput id="po_date" label="Order Date" type="date" value={orderDate} onChange={setOrderDate} />
+        <div className="space-y-2">
+          {items.map((item, idx) => (
+            <div key={idx} className="grid grid-cols-4 gap-2 items-end">
+              <div className="col-span-2">
+                <label htmlFor={`mat_${idx}`} className="block text-sm font-medium text-gray-700">
+                  Material
+                </label>
+                <select
+                  id={`mat_${idx}`}
+                  className="border rounded px-3 py-2 w-full"
+                  value={item.material_type_id}
+                  onChange={(e) => updateItem(idx, "material_type_id", e.target.value)}
+                >
+                  <option value="">Select</option>
+                  {materials.map((m) => (
+                    <option key={m.id} value={m.id}>
+                      {m.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <SZInput
+                id={`qty_${idx}`}
+                label="Qty"
+                type="number"
+                value={String(item.qty)}
+                onChange={(v) => updateItem(idx, "qty", Number(v))}
+              />
+              <div className="pb-3">
+                <SZButton size="sm" variant="destructive" onClick={() => removeItem(idx)}>
+                  Remove
+                </SZButton>
+              </div>
+            </div>
+          ))}
+          <SZButton size="sm" variant="secondary" onClick={addItem}>
+            Add Item
+          </SZButton>
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+      </div>
+      <div className="mt-4 flex justify-end gap-2">
+        <SZButton variant="secondary" onClick={onClose}>
+          Cancel
+        </SZButton>
+        <SZButton onClick={save}>Save</SZButton>
+      </div>
+    </ModalWrapper>
+  );
+};
+
+export default PurchaseOrderForm;

--- a/installer-app/src/lib/hooks/usePurchaseOrders.ts
+++ b/installer-app/src/lib/hooks/usePurchaseOrders.ts
@@ -1,0 +1,92 @@
+import { useState, useEffect, useCallback } from "react";
+import supabase from "../supabaseClient";
+
+export interface PurchaseOrder {
+  id: string;
+  supplier: string;
+  order_date: string;
+  status: string;
+}
+
+export interface PurchaseOrderItem {
+  id: string;
+  order_id: string;
+  material_type_id: string;
+  qty: number;
+}
+
+export default function usePurchaseOrders() {
+  const [orders, setOrders] = useState<PurchaseOrder[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchOrders = useCallback(async () => {
+    setLoading(true);
+    const { data, error } = await supabase
+      .from("purchase_orders")
+      .select("id, supplier, order_date, status")
+      .order("order_date", { ascending: false });
+    if (error) {
+      setError(error.message);
+      setOrders([]);
+    } else {
+      setOrders(data ?? []);
+      setError(null);
+    }
+    setLoading(false);
+  }, []);
+
+  const createOrder = useCallback(
+    async (order: {
+      supplier: string;
+      order_date: string;
+      items: { material_type_id: string; qty: number }[];
+    }) => {
+      const { data, error } = await supabase
+        .from("purchase_orders")
+        .insert({
+          supplier: order.supplier,
+          order_date: order.order_date,
+          status: "draft",
+        })
+        .select()
+        .single();
+      if (error) throw error;
+      if (order.items.length) {
+        const rows = order.items.map((i) => ({ ...i, order_id: data.id }));
+        const { error: itemErr } = await supabase
+          .from("purchase_order_items")
+          .insert(rows);
+        if (itemErr) throw itemErr;
+      }
+      await fetchOrders();
+      return data as PurchaseOrder;
+    },
+    [fetchOrders],
+  );
+
+  const updateStatus = useCallback(async (id: string, status: string) => {
+    const { data, error } = await supabase
+      .from("purchase_orders")
+      .update({ status })
+      .eq("id", id)
+      .select()
+      .single();
+    if (error) throw error;
+    setOrders((list) => list.map((o) => (o.id === id ? (data as PurchaseOrder) : o)));
+    return data as PurchaseOrder;
+  }, []);
+
+  useEffect(() => {
+    fetchOrders();
+  }, [fetchOrders]);
+
+  return {
+    orders,
+    loading,
+    error,
+    fetchOrders,
+    createOrder,
+    updateStatus,
+  } as const;
+}

--- a/installer-app/src/routes.ts
+++ b/installer-app/src/routes.ts
@@ -43,6 +43,7 @@ import RevenueDashboardPage from "./app/reports/RevenueDashboardPage";
 import LeadsPage from "./app/crm/LeadsPage";
 import PaymentReportPage from "./app/admin/reports/payments/PaymentReportPage";
 import InventoryAlertsPage from "./app/admin/InventoryAlertsPage";
+import PurchaseOrdersPage from "./app/inventory/PurchaseOrdersPage";
 import UnderConstructionPage from "./app/UnderConstructionPage";
 import Unauthorized from "./app/Unauthorized";
 import LoginPage from "./app/login/LoginPage";
@@ -180,6 +181,12 @@ export const ROUTES: RouteConfig[] = [
     element: React.createElement(InventoryAlertsPage),
     roles: ["Install Manager", "Admin"],
     label: "Inventory Alerts",
+  },
+  {
+    path: "/inventory/purchase-orders",
+    element: React.createElement(PurchaseOrdersPage),
+    roles: ["Install Manager", "Admin"],
+    label: "Purchase Orders",
   },
   {
     path: "/archived",


### PR DESCRIPTION
## Summary
- implement PurchaseOrdersPage with status filter and creation form
- create PurchaseOrderForm modal component
- add purchase order data hook for CRUD operations
- register purchase order route in navigation

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685a2209110c832d85b30283dd185ced