### PR TITLE
Add reschedule request form

### DIFF
--- a/installer-app/src/app/jobs/RescheduleRequestForm.tsx
+++ b/installer-app/src/app/jobs/RescheduleRequestForm.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from "react";
+import { SZInput } from "../../components/ui/SZInput";
+import { SZTextarea } from "../../components/ui/SZTextarea";
+import { SZButton } from "../../components/ui/SZButton";
+import useAuth from "../../lib/hooks/useAuth";
+import useRescheduleRequests from "../../lib/hooks/useRescheduleRequests";
+
+interface Props {
+  jobId: string;
+}
+
+const RescheduleRequestForm: React.FC<Props> = ({ jobId }) => {
+  const { role } = useAuth();
+  const { requests, createRequest, updateStatus } =
+    useRescheduleRequests(jobId);
+  const [date, setDate] = useState("");
+  const [reason, setReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    if (!date) {
+      setError("Requested date is required");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await createRequest(date, reason);
+      setDate("");
+      setReason("");
+      setError(null);
+    } catch (e: any) {
+      setError(e.message);
+    }
+    setSubmitting(false);
+  };
+
+  const approve = async (id: string, newDate: string) => {
+    try {
+      await updateStatus(id, "approved", newDate);
+    } catch (e: any) {
+      setError(e.message);
+    }
+  };
+
+  const deny = async (id: string) => {
+    try {
+      await updateStatus(id, "denied");
+    } catch (e: any) {
+      setError(e.message);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {role === "Sales" && (
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold">Request Reschedule</h3>
+          <SZInput
+            id="req_date"
+            label="New Date"
+            type="date"
+            value={date}
+            onChange={setDate}
+          />
+          <SZTextarea
+            id="req_reason"
+            label="Reason"
+            value={reason}
+            onChange={setReason}
+            rows={3}
+          />
+          {error && <p className="text-red-600 text-sm">{error}</p>}
+          <SZButton
+            onClick={submit}
+            isLoading={submitting}
+            disabled={submitting}
+          >
+            Submit Request
+          </SZButton>
+        </div>
+      )}
+
+      {role === "Manager" && (
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold">Reschedule Requests</h3>
+          {requests.length === 0 ? (
+            <p className="text-sm text-gray-600">No requests.</p>
+          ) : (
+            <ul className="space-y-2">
+              {requests.map((r) => (
+                <li key={r.id} className="border rounded p-2 space-y-1">
+                  <p className="text-sm">
+                    Requested Date:{" "}
+                    {new Date(r.requested_date).toLocaleDateString()}
+                  </p>
+                  {r.reason && <p className="text-sm italic">{r.reason}</p>}
+                  <p className="text-sm font-semibold">Status: {r.status}</p>
+                  {r.status === "pending" && (
+                    <div className="flex gap-2 mt-2">
+                      <SZButton
+                        size="sm"
+                        onClick={() => approve(r.id, r.requested_date)}
+                      >
+                        Approve
+                      </SZButton>
+                      <SZButton
+                        size="sm"
+                        variant="destructive"
+                        onClick={() => deny(r.id)}
+                      >
+                        Deny
+                      </SZButton>
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+          {error && <p className="text-red-600 text-sm">{error}</p>}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RescheduleRequestForm;

--- a/installer-app/src/lib/hooks/useRescheduleRequests.ts
+++ b/installer-app/src/lib/hooks/useRescheduleRequests.ts
@@ -1,0 +1,145 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import supabase from "../supabaseClient";
+import { useJobs } from "./useJobs";
+
+export interface RescheduleRequest {
+  id: string;
+  job_id: string;
+  requested_date: string;
+  reason: string | null;
+  status: string;
+  created_at: string;
+}
+
+const MAX_RETRIES = 5;
+
+export default function useRescheduleRequests(jobId: string) {
+  const [requests, setRequests] = useState<RescheduleRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const retriesRef = useRef(0);
+  const { updateJob } = useJobs();
+
+  const fetchRequests = useCallback(async () => {
+    if (!jobId) return;
+    setLoading(true);
+    const { data, error } = await supabase
+      .from("reschedule_requests")
+      .select("id, job_id, requested_date, reason, status, created_at")
+      .eq("job_id", jobId)
+      .order("created_at", { ascending: false });
+    if (error) {
+      console.error(error);
+    }
+    setRequests((data as RescheduleRequest[]) ?? []);
+    setLoading(false);
+  }, [jobId]);
+
+  const createRequest = useCallback(
+    async (requested_date: string, reason: string) => {
+      const { data, error } = await supabase
+        .from("reschedule_requests")
+        .insert({ job_id: jobId, requested_date, reason, status: "pending" })
+        .select()
+        .single();
+      if (error) throw error;
+      setRequests((r) => [data as RescheduleRequest, ...r]);
+      return data as RescheduleRequest;
+    },
+    [jobId],
+  );
+
+  const updateStatus = useCallback(
+    async (id: string, status: string, newDate?: string) => {
+      const { data, error } = await supabase
+        .from("reschedule_requests")
+        .update({ status })
+        .eq("id", id)
+        .select()
+        .single();
+      if (error) throw error;
+      setRequests((reqs) =>
+        reqs.map((r) => (r.id === id ? (data as RescheduleRequest) : r)),
+      );
+      if (status === "approved" && newDate) {
+        await updateJob(jobId, { scheduled_date: newDate });
+      }
+      return data as RescheduleRequest;
+    },
+    [jobId, updateJob],
+  );
+
+  useEffect(() => {
+    fetchRequests();
+  }, [fetchRequests]);
+
+  useEffect(() => {
+    if (!jobId) return;
+    const channel = supabase.channel(`reschedule_requests_${jobId}`);
+
+    const subscribe = () => {
+      channel
+        .on(
+          "postgres_changes",
+          {
+            event: "INSERT",
+            schema: "public",
+            table: "reschedule_requests",
+            filter: `job_id=eq.${jobId}`,
+          },
+          (payload) => {
+            setRequests((r) => [payload.new as RescheduleRequest, ...r]);
+          },
+        )
+        .on(
+          "postgres_changes",
+          {
+            event: "UPDATE",
+            schema: "public",
+            table: "reschedule_requests",
+            filter: `job_id=eq.${jobId}`,
+          },
+          (payload) => {
+            setRequests((rs) =>
+              rs.map((r) =>
+                r.id === (payload.new as any).id
+                  ? (payload.new as RescheduleRequest)
+                  : r,
+              ),
+            );
+          },
+        )
+        .subscribe((status) => {
+          if (status === "SUBSCRIBED") {
+            retriesRef.current = 0;
+          } else if (
+            status === "CHANNEL_ERROR" ||
+            status === "TIMED_OUT" ||
+            status === "CLOSED"
+          ) {
+            handleDisconnect();
+          }
+        });
+    };
+
+    const handleDisconnect = () => {
+      supabase.removeChannel(channel);
+      if (retriesRef.current < MAX_RETRIES) {
+        retriesRef.current += 1;
+        setTimeout(subscribe, 1000 * retriesRef.current);
+      }
+    };
+
+    subscribe();
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [jobId]);
+
+  return {
+    requests,
+    loading,
+    fetchRequests,
+    createRequest,
+    updateStatus,
+  } as const;
+}


### PR DESCRIPTION
## Summary
- handle job rescheduling via `RescheduleRequestForm`
- manage requests with new `useRescheduleRequests` hook

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a22564218832da886b2268ef0b00f