### PR TITLE
Add CRM lead pipeline

### DIFF
--- a/installer-app/src/app/crm/LeadPipelinePage.tsx
+++ b/installer-app/src/app/crm/LeadPipelinePage.tsx
@@ -1,0 +1,114 @@
+import React, { useEffect, useRef } from "react";
+import useAuth from "../../lib/hooks/useAuth";
+import useLeads from "../../lib/hooks/useLeads";
+import supabase from "../../lib/supabaseClient";
+
+const statuses = [
+  "new",
+  "attempted_contact",
+  "appointment_scheduled",
+  "consultation_complete",
+  "proposal_sent",
+  "waiting",
+  "won",
+  "lost",
+  "closed",
+];
+
+const MAX_RETRIES = 5;
+
+const LeadPipelinePage: React.FC = () => {
+  const { role, user } = useAuth();
+  const { leads, fetchLeads, updateLeadStatus } = useLeads();
+  const retriesRef = useRef(0);
+
+  useEffect(() => {
+    fetchLeads();
+  }, [fetchLeads]);
+
+  useEffect(() => {
+    const channel = supabase.channel("leads_pipeline");
+    const subscribe = () => {
+      channel
+        .on(
+          "postgres_changes",
+          { event: "*", schema: "public", table: "leads" },
+          () => fetchLeads(),
+        )
+        .subscribe((status) => {
+          if (status === "SUBSCRIBED") {
+            retriesRef.current = 0;
+          } else if (
+            status === "CHANNEL_ERROR" ||
+            status === "TIMED_OUT" ||
+            status === "CLOSED"
+          ) {
+            handleDisconnect();
+          }
+        });
+    };
+
+    const handleDisconnect = () => {
+      supabase.removeChannel(channel);
+      if (retriesRef.current < MAX_RETRIES) {
+        retriesRef.current += 1;
+        setTimeout(subscribe, 1000 * retriesRef.current);
+      }
+    };
+
+    subscribe();
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [fetchLeads]);
+
+  if (!["Sales", "Manager", "Admin"].includes(role ?? "")) {
+    return <div className="p-4">Access denied</div>;
+  }
+
+  const visibleLeads = leads.filter(
+    (l) =>
+      role === "Manager" || role === "Admin" || l.sales_rep_id === user?.id,
+  );
+
+  const onDrop = async (e: React.DragEvent<HTMLDivElement>, status: string) => {
+    const id = e.dataTransfer.getData("text");
+    if (!id) return;
+    await updateLeadStatus(id, status);
+  };
+
+  const onDragStart = (e: React.DragEvent<HTMLDivElement>, id: string) => {
+    e.dataTransfer.setData("text", id);
+  };
+
+  return (
+    <div className="flex overflow-x-auto gap-4 p-4">
+      {statuses.map((stage) => (
+        <div
+          key={stage}
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={(e) => onDrop(e, stage)}
+          className="min-w-[200px] flex-1 bg-gray-50 border rounded p-2"
+        >
+          <h3 className="font-semibold capitalize mb-2">
+            {stage.replace(/_/g, " ")}
+          </h3>
+          {visibleLeads
+            .filter((l) => l.status === stage)
+            .map((l) => (
+              <div
+                key={l.id}
+                draggable
+                onDragStart={(e) => onDragStart(e, l.id)}
+                className="p-2 mb-2 bg-white border rounded shadow-sm text-sm"
+              >
+                {l.clinic_name}
+              </div>
+            ))}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default LeadPipelinePage;

--- a/installer-app/src/routes.ts
+++ b/installer-app/src/routes.ts
@@ -45,6 +45,7 @@ import RevenueDashboardPage from "./app/reports/RevenueDashboardPage";
 import InstallerPerformancePage from "./app/reports/InstallerPerformancePage";
 import LeadsPage from "./app/crm/LeadsPage";
 import LeadForm from "./app/crm/LeadForm";
+import LeadPipelinePage from "./app/crm/LeadPipelinePage";
 import PaymentReportPage from "./app/admin/reports/payments/PaymentReportPage";
 import InventoryAlertsPage from "./app/admin/InventoryAlertsPage";
 import UnderConstructionPage from "./app/UnderConstructionPage";
@@ -244,6 +245,12 @@ export const ROUTES: RouteConfig[] = [
     element: React.createElement(LeadsPage),
     roles: ["Sales", "Manager", "Admin"],
     label: "Leads",
+  },
+  {
+    path: "/crm/pipeline",
+    element: React.createElement(LeadPipelinePage),
+    roles: ["Sales", "Manager", "Admin"],
+    label: "Lead Pipeline",
   },
   {
     path: "/crm/leads/new",


### PR DESCRIPTION
## Summary
- implement `LeadPipelinePage` for Kanban-style lead management
- update routes to register pipeline view

## Testing
- `npx --prefix installer-app jest` *(fails: needs jest package)*

------
https://chatgpt.com/codex/tasks/task_e_685a24b286a4832dbc0d5404f335d15b