### PR TITLE
Implement PWA service worker with offline queue

### DIFF
--- a/installer-app/public/service-worker.js
+++ b/installer-app/public/service-worker.js
@@ -1,0 +1,68 @@
+const CACHE_NAME = "installer-pwa-cache-v1";
+const API_CACHE_NAME = "installer-api-cache-v1";
+const STATIC_ASSETS = ["/", "/index.html"];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(STATIC_ASSETS)),
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== CACHE_NAME && key !== API_CACHE_NAME)
+            .map((key) => caches.delete(key)),
+        ),
+      ),
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const request = event.request;
+  const url = new URL(request.url);
+
+  // API requests - network first
+  if (url.pathname.startsWith("/api") || url.hostname.includes("supabase")) {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const clone = response.clone();
+          caches
+            .open(API_CACHE_NAME)
+            .then((cache) => cache.put(request, clone));
+          return response;
+        })
+        .catch(() => caches.match(request)),
+    );
+    return;
+  }
+
+  // Static assets - cache first
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      if (cached) return cached;
+      return fetch(request).then((response) => {
+        const clone = response.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+        return response;
+      });
+    }),
+  );
+});
+
+self.addEventListener("sync", (event) => {
+  if (event.tag === "sync-offline") {
+    event.waitUntil(
+      self.clients.matchAll().then((clients) => {
+        clients.forEach((client) =>
+          client.postMessage({ type: "SYNC_OFFLINE_QUEUE" }),
+        );
+      }),
+    );
+  }
+});

--- a/installer-app/src/lib/OfflineDataSyncManager.ts
+++ b/installer-app/src/lib/OfflineDataSyncManager.ts
@@ -1,0 +1,85 @@
+export interface QueueItem {
+  url: string;
+  options?: RequestInit;
+}
+
+class OfflineDataSyncManager {
+  private queueKey = "offlineQueue";
+  private isFlushing = false;
+
+  constructor() {
+    if (typeof window !== "undefined") {
+      window.addEventListener("online", () => this.flushQueue());
+      if ("serviceWorker" in navigator) {
+        navigator.serviceWorker.addEventListener("message", (event) => {
+          if (event.data?.type === "SYNC_OFFLINE_QUEUE") {
+            this.flushQueue();
+          }
+        });
+      }
+    }
+  }
+
+  private getQueue(): QueueItem[] {
+    if (typeof window === "undefined") return [];
+    try {
+      return JSON.parse(localStorage.getItem(this.queueKey) || "[]");
+    } catch {
+      return [];
+    }
+  }
+
+  private saveQueue(queue: QueueItem[]): void {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(this.queueKey, JSON.stringify(queue));
+  }
+
+  async queueRequest(
+    url: string,
+    options?: RequestInit,
+  ): Promise<Response | void> {
+    if (navigator.onLine) {
+      try {
+        return await fetch(url, options);
+      } catch (err) {
+        console.error("Request failed, queuing", err);
+      }
+    }
+    this.addToQueue({ url, options });
+    if ("serviceWorker" in navigator && "SyncManager" in window) {
+      try {
+        const reg = await navigator.serviceWorker.ready;
+        await reg.sync.register("sync-offline");
+      } catch (e) {
+        console.error("Background sync registration failed", e);
+      }
+    }
+  }
+
+  private addToQueue(item: QueueItem): void {
+    const queue = this.getQueue();
+    queue.push(item);
+    this.saveQueue(queue);
+  }
+
+  async flushQueue(): Promise<void> {
+    if (this.isFlushing) return;
+    this.isFlushing = true;
+    let queue = this.getQueue();
+    while (queue.length && navigator.onLine) {
+      const item = queue[0];
+      try {
+        await fetch(item.url, item.options);
+        queue.shift();
+        this.saveQueue(queue);
+      } catch (err) {
+        console.error("Failed to sync item", err);
+        break;
+      }
+    }
+    this.isFlushing = false;
+  }
+}
+
+const offlineDataSyncManager = new OfflineDataSyncManager();
+export default offlineDataSyncManager;

--- a/installer-app/src/main.jsx
+++ b/installer-app/src/main.jsx
@@ -1,13 +1,21 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
-import ErrorBoundary from './components/ErrorBoundary';
-import './index.css';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import ErrorBoundary from "./components/ErrorBoundary";
+import "./index.css";
 
-const rootEl = document.getElementById('root');
+const rootEl = document.getElementById("root");
 const root = ReactDOM.createRoot(rootEl);
 root.render(
   <ErrorBoundary>
     <App />
-  </ErrorBoundary>
+  </ErrorBoundary>,
 );
+
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/service-worker.js").catch((err) => {
+      console.error("Service worker registration failed", err);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add service worker for caching and background sync
- queue offline requests and flush when online
- register service worker on app load

## Testing
- `npm test --prefix installer-app` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a29e734f0832da47c590eb90e3446