### PR TITLE
Add global Zustand store

### DIFF
--- a/installer-app/package-lock.json
+++ b/installer-app/package-lock.json
@@ -20,7 +20,8 @@
         "react-icons": "^5.5.0",
         "react-router-dom": "^6.23.0",
         "recharts": "^2.15.4",
-        "stripe": "^12.16.0"
+        "stripe": "^12.16.0",
+        "zustand": "^5.0.5"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.27.2",
@@ -16510,6 +16511,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.5.tgz",
+      "integrity": "sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/installer-app/package.json
+++ b/installer-app/package.json
@@ -13,9 +13,9 @@
   },
   "dependencies": {
     "@fullcalendar/daygrid": "^6.1.17",
-    "@fullcalendar/timegrid": "^6.1.17",
     "@fullcalendar/interaction": "^6.1.17",
     "@fullcalendar/react": "^6.1.17",
+    "@fullcalendar/timegrid": "^6.1.17",
     "@supabase/supabase-js": "^2.50.0",
     "date-fns": "^4.1.0",
     "react": "^18.2.0",
@@ -24,7 +24,8 @@
     "react-icons": "^5.5.0",
     "react-router-dom": "^6.23.0",
     "recharts": "^2.15.4",
-    "stripe": "^12.16.0"
+    "stripe": "^12.16.0",
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.27.2",

--- a/installer-app/src/App.jsx
+++ b/installer-app/src/App.jsx
@@ -9,6 +9,7 @@ import {
 import GlobalLayout from "./components/navigation/GlobalLayout";
 import { ROUTES } from "./routes";
 import { AuthProvider } from "./lib/hooks/useAuth";
+import { GlobalStoreProvider } from "./lib/state";
 import { RequireAuth as RequireAuthOutlet } from "./components/auth/RequireAuth";
 import RequireRole from "./components/auth/RequireRole";
 
@@ -19,28 +20,30 @@ const App = () => {
   return (
     <Router>
       <AuthProvider>
-        <Suspense fallback={<GlobalLoading />}>
-          <Routes>
-            {publicRoutes.map((r) => (
-              <Route key={r.path} path={r.path} element={r.element} />
-            ))}
-            <Route element={<RequireAuthOutlet />}>
-              <Route element={<GlobalLayout />}>
-                {protectedRoutes.map(({ path, element, roles }) => (
-                  <Route
-                    key={path}
-                    path={path}
-                    element={
-                      <RequireRole allowed={roles}>{element}</RequireRole>
-                    }
-                  />
-                ))}
-                <Route path="*" element={<Navigate to="/" replace />} />
+        <GlobalStoreProvider>
+          <Suspense fallback={<GlobalLoading />}>
+            <Routes>
+              {publicRoutes.map((r) => (
+                <Route key={r.path} path={r.path} element={r.element} />
+              ))}
+              <Route element={<RequireAuthOutlet />}>
+                <Route element={<GlobalLayout />}>
+                  {protectedRoutes.map(({ path, element, roles }) => (
+                    <Route
+                      key={path}
+                      path={path}
+                      element={
+                        <RequireRole allowed={roles}>{element}</RequireRole>
+                      }
+                    />
+                  ))}
+                  <Route path="*" element={<Navigate to="/" replace />} />
+                </Route>
               </Route>
-            </Route>
-            <Route path="*" element={<Navigate to="/login" replace />} />
-          </Routes>
-        </Suspense>
+              <Route path="*" element={<Navigate to="/login" replace />} />
+            </Routes>
+          </Suspense>
+        </GlobalStoreProvider>
       </AuthProvider>
     </Router>
   );

--- a/installer-app/src/__tests__/GlobalStore.test.tsx
+++ b/installer-app/src/__tests__/GlobalStore.test.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { renderHook, act } from "@testing-library/react";
+import { GlobalStoreProvider, useStore } from "../lib/state";
+
+test("updates state via store action", () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <GlobalStoreProvider>{children}</GlobalStoreProvider>
+  );
+  const { result } = renderHook(() => useStore((s) => [s.role, s.setRole]), {
+    wrapper,
+  });
+  act(() => {
+    result.current[1]("Admin");
+  });
+  expect(result.current[0]).toBe("Admin");
+});

--- a/installer-app/src/lib/state/GlobalStore.tsx
+++ b/installer-app/src/lib/state/GlobalStore.tsx
@@ -1,0 +1,93 @@
+import { ReactNode, createContext, useContext, useRef } from "react";
+import { createStore, StoreApi, useStore as useZustandStore } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface AuthSlice {
+  session: any | null;
+  user: any | null;
+  role: string | null;
+  setSession: (session: any | null) => void;
+  setUser: (user: any | null) => void;
+  setRole: (role: string | null) => void;
+}
+
+interface UiSlice {
+  modals: Record<string, boolean>;
+  breadcrumbs: string[];
+  loading: boolean;
+  showModal: (key: string, value: boolean) => void;
+  setBreadcrumbs: (crumbs: string[]) => void;
+  setLoading: (flag: boolean) => void;
+}
+
+interface JobSlice {
+  currentJobId: string | null;
+  jobCache: Record<string, any>;
+  setCurrentJob: (id: string | null) => void;
+  cacheJob: (id: string, data: any) => void;
+}
+
+export type GlobalState = AuthSlice & UiSlice & JobSlice;
+
+const createAuthSlice = (
+  set: StoreApi<GlobalState>["setState"],
+): AuthSlice => ({
+  session: null,
+  user: null,
+  role: null,
+  setSession: (session) => set({ session }),
+  setUser: (user) => set({ user }),
+  setRole: (role) => set({ role }),
+});
+
+const createUiSlice = (
+  set: StoreApi<GlobalState>["setState"],
+  get: StoreApi<GlobalState>["getState"],
+): UiSlice => ({
+  modals: {},
+  breadcrumbs: [],
+  loading: false,
+  showModal: (key, value) => set({ modals: { ...get().modals, [key]: value } }),
+  setBreadcrumbs: (crumbs) => set({ breadcrumbs: crumbs }),
+  setLoading: (flag) => set({ loading: flag }),
+});
+
+const createJobSlice = (
+  set: StoreApi<GlobalState>["setState"],
+  get: StoreApi<GlobalState>["getState"],
+): JobSlice => ({
+  currentJobId: null,
+  jobCache: {},
+  setCurrentJob: (id) => set({ currentJobId: id }),
+  cacheJob: (id, data) => set({ jobCache: { ...get().jobCache, [id]: data } }),
+});
+
+const StoreContext = createContext<StoreApi<GlobalState> | null>(null);
+
+export function GlobalStoreProvider({ children }: { children: ReactNode }) {
+  const storeRef = useRef<StoreApi<GlobalState>>();
+  if (!storeRef.current) {
+    storeRef.current = createStore<GlobalState>(
+      persist(
+        (set, get) => ({
+          ...createAuthSlice(set),
+          ...createUiSlice(set, get),
+          ...createJobSlice(set, get),
+        }),
+        { name: "global-store" },
+      ),
+    );
+  }
+  return (
+    <StoreContext.Provider value={storeRef.current}>
+      {children}
+    </StoreContext.Provider>
+  );
+}
+
+export function useStore<T>(selector: (state: GlobalState) => T): T {
+  const store = useContext(StoreContext);
+  if (!store)
+    throw new Error("useStore must be used within GlobalStoreProvider");
+  return useZustandStore(store, selector);
+}

--- a/installer-app/src/lib/state/index.ts
+++ b/installer-app/src/lib/state/index.ts
@@ -1,0 +1,2 @@
+export { GlobalStoreProvider, useStore } from "./GlobalStore";
+export type { GlobalState } from "./GlobalStore";


### PR DESCRIPTION
## Summary
- add zustand dependency
- create GlobalStore provider and `useStore`
- wrap app with provider
- test state updates via GlobalStore

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test -- -t GlobalStore` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_685a2a062d3c832dbdcdba5e13cc3ec9