### PR TITLE
Add rescheduling dashboard

### DIFF
--- a/installer-app/src/app/dispatch/ReschedulingDashboard.tsx
+++ b/installer-app/src/app/dispatch/ReschedulingDashboard.tsx
@@ -1,0 +1,103 @@
+import React, { useState } from "react";
+import useAllRescheduleRequests from "../../lib/hooks/useAllRescheduleRequests";
+import LoadingFallback from "../../components/ui/LoadingFallback";
+import EmptyState from "../../components/ui/EmptyState";
+import ErrorBoundary from "../../components/ui/ErrorBoundary";
+import { SZTable } from "../../components/ui/SZTable";
+import InstallerSelector from "../../components/filters/InstallerSelector";
+import StatusFilter from "../../components/filters/StatusFilter";
+import { SZButton } from "../../components/ui/SZButton";
+
+const ReschedulingDashboard: React.FC = () => {
+  const [status, setStatus] = useState<string>("pending");
+  const [installer, setInstaller] = useState<string>("");
+  const { requests, loading, error, updateStatus } = useAllRescheduleRequests({
+    status,
+    installerId: installer,
+  });
+
+  const approve = (id: string, date: string) => {
+    updateStatus(id, "approved", date);
+  };
+
+  const deny = (id: string) => {
+    updateStatus(id, "denied");
+  };
+
+  return (
+    <ErrorBoundary>
+      <div className="p-4 space-y-4">
+        <h1 className="text-2xl font-bold">Reschedule Requests</h1>
+        <div className="flex gap-4">
+          <StatusFilter
+            options={[
+              { value: "pending", label: "Pending" },
+              { value: "approved", label: "Approved" },
+              { value: "denied", label: "Denied" },
+            ]}
+            value={status}
+            onChange={setStatus}
+          />
+          <InstallerSelector value={installer} onChange={setInstaller} />
+        </div>
+        {loading ? (
+          <LoadingFallback />
+        ) : error ? (
+          <EmptyState message="Failed to load requests." />
+        ) : requests.length === 0 ? (
+          <EmptyState message="No reschedule requests found." />
+        ) : (
+          <SZTable
+            headers={[
+              "Job",
+              "Current Date",
+              "Requested Date",
+              "Reason",
+              "Status",
+              "Actions",
+            ]}
+          >
+            {requests.map((r) => (
+              <tr key={r.id} className="border-t">
+                <td className="p-2 border">
+                  {r.jobs?.clinic_name || r.job_id}
+                </td>
+                <td className="p-2 border">
+                  {r.jobs?.scheduled_date
+                    ? new Date(r.jobs.scheduled_date).toLocaleDateString()
+                    : ""}
+                </td>
+                <td className="p-2 border">
+                  {new Date(r.requested_date).toLocaleDateString()}
+                </td>
+                <td className="p-2 border">{r.reason}</td>
+                <td className="p-2 border">{r.status}</td>
+                <td className="p-2 border">
+                  {r.status === "pending" && (
+                    <div className="flex gap-2">
+                      <SZButton
+                        size="sm"
+                        onClick={() => approve(r.id, r.requested_date)}
+                      >
+                        Approve
+                      </SZButton>
+                      <SZButton
+                        size="sm"
+                        variant="destructive"
+                        onClick={() => deny(r.id)}
+                      >
+                        Deny
+                      </SZButton>
+                    </div>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </SZTable>
+        )}
+      </div>
+    </ErrorBoundary>
+  );
+};
+
+export default ReschedulingDashboard;

--- a/installer-app/src/lib/hooks/useAllRescheduleRequests.ts
+++ b/installer-app/src/lib/hooks/useAllRescheduleRequests.ts
@@ -1,0 +1,97 @@
+import { useState, useEffect, useCallback } from "react";
+import supabase from "../supabaseClient";
+
+export interface DashboardRescheduleRow {
+  id: string;
+  job_id: string;
+  requested_date: string;
+  reason: string | null;
+  status: string;
+  created_at: string;
+  jobs?: {
+    id: string;
+    clinic_name?: string | null;
+    scheduled_date: string | null;
+    assigned_to: string | null;
+  } | null;
+}
+
+export interface RescheduleFilters {
+  installerId?: string;
+  status?: string;
+}
+
+export function useAllRescheduleRequests(filters: RescheduleFilters = {}) {
+  const [requests, setRequests] = useState<DashboardRescheduleRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchRequests = useCallback(async () => {
+    setLoading(true);
+    let query = supabase
+      .from("reschedule_requests")
+      .select(
+        "id, job_id, requested_date, reason, status, created_at, jobs(id, clinic_name, scheduled_date, assigned_to)",
+      )
+      .order("created_at", { ascending: false });
+    if (filters.status) query = query.eq("status", filters.status);
+    if (filters.installerId)
+      query = query.eq("jobs.assigned_to", filters.installerId);
+    const { data, error } = await query;
+    if (error) {
+      setError(error.message);
+      setRequests([]);
+    } else {
+      const mapped = (data ?? []).map((r: any) => ({
+        ...r,
+        jobs: r.jobs ?? null,
+      }));
+      setRequests(mapped);
+      setError(null);
+    }
+    setLoading(false);
+  }, [filters.status, filters.installerId]);
+
+  const updateStatus = useCallback(
+    async (id: string, status: string, newDate?: string) => {
+      const { data, error } = await supabase
+        .from("reschedule_requests")
+        .update({ status })
+        .eq("id", id)
+        .select(
+          "id, job_id, requested_date, reason, status, created_at, jobs(id, clinic_name, scheduled_date, assigned_to)",
+        )
+        .single();
+      if (error) throw error;
+      setRequests((reqs) =>
+        reqs.map((r) =>
+          r.id === id
+            ? { ...(data as any), jobs: (data as any).jobs ?? null }
+            : r,
+        ),
+      );
+      if (status === "approved" && newDate) {
+        await supabase
+          .from("jobs")
+          .update({ scheduled_date: newDate })
+          .eq("id", (data as any).job_id);
+        await supabase.functions.invoke("send_reschedule_notification", {
+          body: JSON.stringify({
+            job_id: (data as any).job_id,
+            new_date: newDate,
+          }),
+        });
+      }
+      return data as DashboardRescheduleRow;
+    },
+    [],
+  );
+
+  useEffect(() => {
+    fetchRequests();
+  }, [fetchRequests]);
+
+  return { requests, loading, error, fetchRequests, updateStatus } as const;
+}
+
+export default useAllRescheduleRequests;

--- a/installer-app/src/routes.ts
+++ b/installer-app/src/routes.ts
@@ -38,6 +38,7 @@ import InvoiceGenerator from "./app/install-manager/InvoiceGenerator";
 import PaymentLogger from "./app/install-manager/PaymentLogger";
 import NotificationsPanel from "./app/install-manager/NotificationsPanel";
 import MessagesPanel from "./app/messages/MessagesPanel";
+import ReschedulingDashboard from "./app/dispatch/ReschedulingDashboard";
 import TimeTrackingPanel from "./app/time-tracking/TimeTrackingPanel";
 import ReportsPage from "./app/reports/ReportsPage";
 import TechnicianPayReportPage from "./app/reports/TechnicianPayReportPage";
@@ -245,6 +246,12 @@ export const ROUTES: RouteConfig[] = [
     element: React.createElement(NotificationsPanel),
     roles: ["Install Manager", "Admin"],
     label: "Notifications",
+  },
+  {
+    path: "/dispatch/rescheduling",
+    element: React.createElement(ReschedulingDashboard),
+    roles: ["Manager", "Dispatcher"],
+    label: "Reschedule Requests",
   },
   {
     path: "/clients",


### PR DESCRIPTION
## Summary
- create `useAllRescheduleRequests` hook
- add `ReschedulingDashboard` page for dispatch managers
- register dashboard route

## Testing
- `npm test -- -i` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_685a2aa7a1fc832dbc46865efe0f9f1a