### PR TITLE
Fix missing toast dependency

### DIFF
--- a/installer-app/package-lock.json
+++ b/installer-app/package-lock.json
@@ -17,6 +17,7 @@
         "react": "^18.2.0",
         "react-big-calendar": "^1.19.4",
         "react-dom": "^18.2.0",
+        "react-hot-toast": "^2.5.2",
         "react-icons": "^5.5.0",
         "react-router-dom": "^6.23.0",
         "recharts": "^2.15.4",
@@ -8798,6 +8799,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -14172,6 +14182,23 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
+      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-icons": {

--- a/installer-app/package.json
+++ b/installer-app/package.json
@@ -21,6 +21,7 @@
     "react": "^18.2.0",
     "react-big-calendar": "^1.19.4",
     "react-dom": "^18.2.0",
+    "react-hot-toast": "^2.5.2",
     "react-icons": "^5.5.0",
     "react-router-dom": "^6.23.0",
     "recharts": "^2.15.4",


### PR DESCRIPTION
## Summary
- add `react-hot-toast` to installer app dependencies

## Testing
- `npx jest -i --json`

------
https://chatgpt.com/codex/tasks/task_e_685a2d69c468832d8aa77358a2e70341