### PR TITLE
Add purchase order receipt page

### DIFF
--- a/installer-app/src/app/inventory/ReceivePOPage.tsx
+++ b/installer-app/src/app/inventory/ReceivePOPage.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from "react";
+import { Navigate, useParams } from "react-router-dom";
+import { SZButton } from "../../components/ui/SZButton";
+import { SZTable } from "../../components/ui/SZTable";
+import {
+  GlobalLoading,
+  GlobalError,
+} from "../../components/global-states";
+import useAuth from "../../lib/hooks/useAuth";
+import usePurchaseOrder from "../../lib/hooks/usePurchaseOrder";
+import supabase from "../../lib/supabaseClient";
+
+const ReceivePOPage: React.FC = () => {
+  const { poId } = useParams<{ poId: string }>();
+  const { role } = useAuth();
+  const { order, loading, error, refresh } = usePurchaseOrder(poId ?? null);
+  const [qtys, setQtys] = useState<Record<string, number>>({});
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!order) return;
+    const initial: Record<string, number> = {};
+    order.items.forEach((item) => {
+      initial[item.id] = item.qty;
+    });
+    setQtys(initial);
+  }, [order]);
+
+  if (role !== "Admin" && role !== "Install Manager") {
+    return <Navigate to="/unauthorized" replace />;
+  }
+
+  const handleSave = async () => {
+    if (!order) return;
+    setSaving(true);
+    setSaveError(null);
+    const items = order.items.map((it) => ({
+      item_id: it.id,
+      qty: qtys[it.id] ?? 0,
+    }));
+    const { error: rpcErr } = await supabase.rpc("receive_purchase_order", {
+      po_id: order.id,
+      items,
+    });
+    if (rpcErr) {
+      setSaveError(rpcErr.message);
+    } else {
+      await supabase
+        .from("purchase_orders")
+        .update({ status: "received" })
+        .eq("id", order.id);
+      refresh();
+    }
+    setSaving(false);
+  };
+
+  if (loading) return <GlobalLoading />;
+  if (error || !order) return <GlobalError message={error || "Order not found"} />;
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Receive Purchase Order</h1>
+      <p>
+        Supplier: {order.supplier} — {new Date(order.order_date).toLocaleDateString()}
+      </p>
+      {saveError && <p className="text-red-600 text-sm">{saveError}</p>}
+      <SZTable headers={["Material", "Ordered Qty", "Received Qty"]}>
+        {order.items.map((item) => (
+          <tr key={item.id} className="border-t">
+            <td className="p-2 border">
+              {item.material_name ?? item.material_type_id}
+            </td>
+            <td className="p-2 border text-right">{item.qty}</td>
+            <td className="p-2 border">
+              <input
+                type="number"
+                min={0}
+                className="border rounded px-2 py-1 w-24"
+                value={qtys[item.id] ?? 0}
+                onChange={(e) =>
+                  setQtys({ ...qtys, [item.id]: Number(e.target.value) })
+                }
+              />
+            </td>
+          </tr>
+        ))}
+      </SZTable>
+      <div className="flex justify-end">
+        <SZButton onClick={handleSave} isLoading={saving}>
+          Save Receipt
+        </SZButton>
+      </div>
+    </div>
+  );
+};
+
+export default ReceivePOPage;

--- a/installer-app/src/lib/hooks/usePurchaseOrder.ts
+++ b/installer-app/src/lib/hooks/usePurchaseOrder.ts
@@ -1,0 +1,67 @@
+import { useState, useEffect, useCallback } from "react";
+import supabase from "../supabaseClient";
+
+export interface PurchaseOrderItemDetail {
+  id: string;
+  order_id: string;
+  material_type_id: string;
+  qty: number;
+  material_name?: string | null;
+}
+
+export interface PurchaseOrderDetail {
+  id: string;
+  supplier: string;
+  order_date: string;
+  status: string;
+  items: PurchaseOrderItemDetail[];
+}
+
+export default function usePurchaseOrder(poId: string | null) {
+  const [order, setOrder] = useState<PurchaseOrderDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchOrder = useCallback(async () => {
+    if (!poId) {
+      setOrder(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const { data, error } = await supabase
+      .from("purchase_orders")
+      .select(
+        "id, supplier, order_date, status, purchase_order_items(id, order_id, material_type_id, qty, material_types(name))"
+      )
+      .eq("id", poId)
+      .single();
+    if (error) {
+      setError(error.message);
+      setOrder(null);
+    } else {
+      const mapped: PurchaseOrderDetail = {
+        id: data.id,
+        supplier: data.supplier,
+        order_date: data.order_date,
+        status: data.status,
+        items: (data.purchase_order_items ?? []).map((it: any) => ({
+          id: it.id,
+          order_id: it.order_id,
+          material_type_id: it.material_type_id,
+          qty: it.qty,
+          material_name: it.material_types?.name ?? null,
+        })),
+      };
+      setOrder(mapped);
+      setError(null);
+    }
+    setLoading(false);
+  }, [poId]);
+
+  useEffect(() => {
+    fetchOrder();
+  }, [fetchOrder]);
+
+  return { order, loading, error, refresh: fetchOrder } as const;
+}

--- a/installer-app/src/routes.ts
+++ b/installer-app/src/routes.ts
@@ -56,6 +56,7 @@ import PaymentReportPage from "./app/admin/reports/payments/PaymentReportPage";
 import ARAgingReportPage from "./app/admin/reports/ar-aging/ARAgingReportPage";
 import InventoryAlertsPage from "./app/admin/InventoryAlertsPage";
 import PurchaseOrdersPage from "./app/inventory/PurchaseOrdersPage";
+import ReceivePOPage from "./app/inventory/ReceivePOPage";
 import UnderConstructionPage from "./app/UnderConstructionPage";
 import Unauthorized from "./app/Unauthorized";
 import LoginPage from "./app/login/LoginPage";
@@ -205,6 +206,11 @@ export const ROUTES: RouteConfig[] = [
     element: React.createElement(PurchaseOrdersPage),
     roles: ["Install Manager", "Admin"],
     label: "Purchase Orders",
+  },
+  {
+    path: "/inventory/receive/:poId",
+    element: React.createElement(ReceivePOPage),
+    roles: ["Install Manager", "Admin"],
   },
   {
     path: "/archived",


### PR DESCRIPTION
## Summary
- add `ReceivePOPage` for recording incoming purchase orders
- add `usePurchaseOrder` hook to fetch order details
- register page route in app routing

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a30fa1480832da5054cace7f600f8