### PR TITLE
Add overbooking check function

### DIFF
--- a/installer-app/api/jobs/check_overbooking.sql
+++ b/installer-app/api/jobs/check_overbooking.sql
@@ -1,0 +1,21 @@
+create or replace function check_overbooking(
+  p_installer_id uuid,
+  p_start_time timestamptz,
+  p_end_time timestamptz
+) returns void as $$
+declare
+  v_count integer;
+begin
+  select count(*)
+    into v_count
+    from jobs
+    where installer_id = p_installer_id
+      and start_time < p_end_time
+      and end_time > p_start_time;
+
+  if v_count > 0 then
+    raise exception 'Installer has an overlapping job during this time';
+  end if;
+end;
+$$ language plpgsql;
+


### PR DESCRIPTION
## Summary
- add SQL RPC `check_overbooking` for validating installer schedules
- execute a single existing test to ensure environment works

## Testing
- `npm test -- src/__tests__/apiJobs.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685a31101254832d9b2807c89ed7bf4c