### PR TITLE
Add install time report

### DIFF
--- a/installer-app/src/app/reports/InstallTimeReportPage.tsx
+++ b/installer-app/src/app/reports/InstallTimeReportPage.tsx
@@ -1,0 +1,80 @@
+import React, { useMemo, useState } from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { DateRangeFilter } from "../../components/ui/filters/DateRangeFilter";
+import { SZTable } from "../../components/ui/SZTable";
+import {
+  GlobalLoading,
+  GlobalError,
+  GlobalEmpty,
+} from "../../components/global-states";
+import useInstallTimeReport from "../../lib/hooks/useInstallTimeReport";
+
+const InstallTimeReportPage: React.FC = () => {
+  const today = new Date().toISOString().slice(0, 10);
+  const past = new Date();
+  past.setDate(past.getDate() - 30);
+  const [range, setRange] = useState({
+    start: past.toISOString().slice(0, 10),
+    end: today,
+  });
+  const { rows, loading, error } = useInstallTimeReport(range.start, range.end);
+
+  const chartData = useMemo(
+    () =>
+      rows.map((r) => ({
+        rooms: r.room_count ?? 0,
+        duration: r.avg_duration ?? 0,
+      })),
+    [rows],
+  );
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Install Time by Room Count</h1>
+      <DateRangeFilter value={range} onChange={setRange} />
+      {loading && <GlobalLoading />}
+      {error && <GlobalError message={error} />}
+      {!loading && !error && rows.length === 0 && (
+        <GlobalEmpty message="No data" />
+      )}
+      {!loading && !error && rows.length > 0 && (
+        <>
+          <div className="h-72 bg-white p-4 rounded shadow">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={chartData}
+                margin={{ top: 5, right: 20, bottom: 5, left: 0 }}
+              >
+                <XAxis dataKey="rooms" label={{ value: "Rooms", position: "insideBottom", offset: -5 }} />
+                <YAxis label={{ value: "Hours", angle: -90, position: "insideLeft" }} />
+                <Tooltip />
+                <Bar dataKey="duration" fill="#8884d8" name="Avg Hours" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="overflow-x-auto">
+            <SZTable headers={["Rooms", "Avg Hours"]}>
+              {rows.map((r) => (
+                <tr key={r.room_count ?? "none"} className="border-t">
+                  <td className="p-2 border">{r.room_count}</td>
+                  <td className="p-2 border text-right">
+                    {r.avg_duration?.toFixed(2) ?? ""}
+                  </td>
+                </tr>
+              ))}
+            </SZTable>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default InstallTimeReportPage;

--- a/installer-app/src/lib/hooks/useInstallTimeReport.ts
+++ b/installer-app/src/lib/hooks/useInstallTimeReport.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+import supabase from "../supabaseClient";
+
+export interface InstallTimeRow {
+  room_count: number | null;
+  avg_duration: number | null;
+}
+
+export default function useInstallTimeReport(start?: string, end?: string) {
+  const [rows, setRows] = useState<InstallTimeRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true);
+      let query = supabase
+        .from("jobs")
+        .select("id, room_count, start_time, end_time");
+      if (start) query = query.gte("start_time", start);
+      if (end) query = query.lte("end_time", end);
+      const { data, error } = await query;
+      if (error) {
+        setError(error.message);
+        setRows([]);
+        setLoading(false);
+        return;
+      }
+      const map: Record<number, { total: number; count: number }> = {};
+      (data ?? []).forEach((j: any) => {
+        const rooms = Number(j.room_count ?? 0);
+        if (!map[rooms]) map[rooms] = { total: 0, count: 0 };
+        if (j.start_time && j.end_time) {
+          const dur =
+            (new Date(j.end_time).getTime() -
+              new Date(j.start_time).getTime()) /
+            3600000;
+          map[rooms].total += dur;
+          map[rooms].count += 1;
+        }
+      });
+      const result: InstallTimeRow[] = Object.keys(map).map((r) => ({
+        room_count: Number(r),
+        avg_duration: map[Number(r)].count
+          ? map[Number(r)].total / map[Number(r)].count
+          : null,
+      }));
+      result.sort((a, b) => (a.room_count ?? 0) - (b.room_count ?? 0));
+      setRows(result);
+      setError(null);
+      setLoading(false);
+    }
+    load();
+  }, [start, end]);
+
+  return { rows, loading, error } as const;
+}

--- a/installer-app/src/routes.ts
+++ b/installer-app/src/routes.ts
@@ -48,6 +48,7 @@ import LeadFunnelDashboardPage from "./app/reports/LeadFunnelDashboardPage";
 import RevenueDashboardPage from "./app/reports/RevenueDashboardPage";
 import ARRevenueReportPage from "./app/reports/ARRevenueReportPage";
 import InstallerPerformancePage from "./app/reports/InstallerPerformancePage";
+import InstallTimeReportPage from "./app/reports/InstallTimeReportPage";
 import LeadsPage from "./app/crm/LeadsPage";
 import LeadForm from "./app/crm/LeadForm";
 import LeadPipelinePage from "./app/crm/LeadPipelinePage";
@@ -353,6 +354,12 @@ export const ROUTES: RouteConfig[] = [
     element: React.createElement(InstallerPerformancePage),
     roles: ["Admin", "Manager"],
     label: "Installer Performance",
+  },
+  {
+    path: "/reports/install-time",
+    element: React.createElement(InstallTimeReportPage),
+    roles: ["Admin", "Manager"],
+    label: "Install Time",
   },
   {
     path: "/reports/revenue",


### PR DESCRIPTION
## Summary
- add InstallTimeReportPage with chart and table
- create hook to fetch install duration by room count
- expose new page via routes

## Testing
- `npm test --silent` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_685a34b71508832d8032efefd8740937