### PR TITLE
Fix global loading export

### DIFF
--- a/installer-app/src/components/global-states/index.ts
+++ b/installer-app/src/components/global-states/index.ts
@@ -1,3 +1,3 @@
-export { GlobalError } from './GlobalError';
-export { GlobalLoading } from './GlobalLoading';
-export { GlobalEmpty } from './GlobalEmpty';
+export { default as GlobalError } from './GlobalError';
+export { default as GlobalLoading } from './GlobalLoading';
+export { default as GlobalEmpty } from './GlobalEmpty';


### PR DESCRIPTION
## Summary
- export default components from `global-states`

## Testing
- `npm run build`
- `npm test --silent` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_685a4bfc37bc832db4d4ebac5cd461ae