### PR TITLE
Add enums for job and quote statuses

### DIFF
--- a/installer-app/api/migrations/041_create_job_status_enum.sql
+++ b/installer-app/api/migrations/041_create_job_status_enum.sql
@@ -1,0 +1,12 @@
+create type if not exists job_status as enum (
+  'created',
+  'assigned',
+  'in_progress',
+  'needs_qa',
+  'complete',
+  'rework',
+  'archived',
+  'ready_for_invoice',
+  'invoiced',
+  'paid'
+);

--- a/installer-app/api/migrations/042_alter_jobs_use_job_status_enum.sql
+++ b/installer-app/api/migrations/042_alter_jobs_use_job_status_enum.sql
@@ -1,0 +1,5 @@
+alter table jobs drop constraint if exists jobs_status_check;
+
+alter table jobs
+  alter column status type job_status using status::job_status,
+  alter column status set default 'created';

--- a/installer-app/api/migrations/043_alter_quotes_use_quote_status_enum.sql
+++ b/installer-app/api/migrations/043_alter_quotes_use_quote_status_enum.sql
@@ -1,0 +1,5 @@
+create type if not exists quote_status as enum ('draft', 'pending', 'approved', 'rejected');
+
+alter table quotes
+  alter column status type quote_status using status::quote_status,
+  alter column status set default 'draft';


### PR DESCRIPTION
## Summary
- define `job_status` enum and migrate `jobs.status` to use it
- ensure `quotes.status` uses `quote_status`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b3d032c24832d8cd6d66803505001