### PR TITLE
Align users table with auth schema

### DIFF
--- a/installer-app/api/migrations/029_create_pending_user_function.sql
+++ b/installer-app/api/migrations/029_create_pending_user_function.sql
@@ -3,13 +3,13 @@ returns void as $$
 declare
   uid uuid;
 begin
-  insert into public.users (email, status)
-  values (email, 'pending')
-  on conflict (email) do update set email = excluded.email
+  insert into auth.users (email)
+  values (email)
+  on conflict (email) do nothing
   returning id into uid;
 
   if uid is null then
-    select id into uid from public.users where public.users.email = email;
+    select id into uid from auth.users where auth.users.email = email;
   end if;
 
   insert into public.user_roles (user_id, role)

--- a/installer-app/api/migrations/041_sync_public_users.sql
+++ b/installer-app/api/migrations/041_sync_public_users.sql
@@ -1,0 +1,5 @@
+-- Drop old users table and replace with view mapping to auth.users
+DROP TABLE IF EXISTS public.users CASCADE;
+
+CREATE VIEW public.users AS
+SELECT id, email, full_name FROM auth.users;

--- a/installer-app/src/app/admin/users/AdminUserForm.tsx
+++ b/installer-app/src/app/admin/users/AdminUserForm.tsx
@@ -22,7 +22,7 @@ const AdminUserForm: React.FC<Props> = ({ user, onClose }) => {
   const save = async () => {
     if (form.id) {
       await supabase
-        .from("users")
+        .from("auth.users")
         .update({
           email: form.email,
           full_name: form.full_name,
@@ -30,7 +30,7 @@ const AdminUserForm: React.FC<Props> = ({ user, onClose }) => {
         })
         .eq("id", form.id);
     } else {
-      await supabase.from("users").insert({
+      await supabase.from("auth.users").insert({
         email: form.email,
         full_name: form.full_name,
         active: form.active,


### PR DESCRIPTION
## Summary
- update `create_pending_user` function to write to `auth.users`
- drop custom `public.users` table and expose a view to `auth.users`
- adjust AdminUserForm to use the `auth.users` table
- refresh schema lock

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b3d04159c832db5eaf014db03632d